### PR TITLE
Fix quotes with syntax properties

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -246,8 +246,8 @@ fn bar() { }" 14 67))
    "/**
  *
  */"
-   8
-   "This is a very very very very very very very long string"
+   7
+   " This is a very very very very very very very long string"
    "/**
  * This is a very very very very
  * very very very long string
@@ -317,8 +317,7 @@ fn foo() {
     /*!
      * this is a nested doc comment
      */
-
-    //! And so is this
+    \n    //! And so is this
 }"))
 
 (ert-deftest indent-inside-braces ()

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -899,3 +899,11 @@ list of substrings of `STR' each followed by its face."
    "'\"'; let"
    '("'\"'" font-lock-string-face
      "let" font-lock-keyword-face)))
+
+(ert-deftest font-lock-single-quote-character-literal ()
+  (rust-test-font-lock
+   "fn main() { let ch = '\\''; }"
+   '("fn" font-lock-keyword-face
+     "main" font-lock-function-name-face
+     "let" font-lock-keyword-face
+     "'\\''" font-lock-string-face)))

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -526,6 +526,18 @@ fn foo() {
 "
    ))
 
+;; Closing braces in single char literals and strings should not confuse the indentation
+(ert-deftest indent-closing-braces-in-char-literals ()
+  (test-indent
+   "
+fn foo() {
+    { bar('}'); }
+    { bar(']'); }
+    { bar(')'); }
+}
+"
+   ))
+
 (setq rust-test-motion-string
       "
 fn fn1(arg: int) -> bool {

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -893,3 +893,9 @@ list of substrings of `STR' each followed by its face."
    "/* #[foo] */"
    '("/* " font-lock-comment-delimiter-face
      "#[foo] */" font-lock-comment-face)))
+
+(ert-deftest font-lock-double-quote-character-literal ()
+  (rust-test-font-lock
+   "'\"'; let"
+   '("'\"'" font-lock-string-face
+     "let" font-lock-keyword-face)))


### PR DESCRIPTION
This uses syntax properties to make it so that emacs recognizes the single quote, rather than the double quote, as the string delimiter within character literals, while leaving the syntax unchanged elsewhere.

Also included is a commit that restores ERT tests that were inadvertently broken by an earlier commit (removing trailing whitespace broke the tests--I restored them and made it so they are no longer dependent on having trailing whitespace in the code.)

Fixes #1.
Fixes #6.