### PR TITLE
Add travis config (and make tests runnable on emacs 23)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: generic
+
+env:
+  matrix:
+    - EMACS=emacs23
+    - EMACS=emacs24
+    - EMACS=emacs-snapshot
+
+install:
+  - if [ "$EMACS" = 'emacs23' ]; then
+       sudo apt-get -qq update &&
+       sudo apt-get -qq -f install &&
+       sudo apt-get -qq install emacs23-gtk emacs23-el;
+    fi
+  - if [ "$EMACS" = 'emacs24' ]; then
+       sudo add-apt-repository -y ppa:cassou/emacs &&
+       sudo apt-get -qq update &&
+       sudo apt-get -qq -f install &&
+       sudo apt-get -qq install emacs24 emacs24-el;
+    fi
+  - if [ "$EMACS" = 'emacs-snapshot' ]; then
+       sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
+       sudo apt-get -qq update &&
+       sudo apt-get -qq -f install &&
+       sudo apt-get -qq install emacs-snapshot &&
+       sudo apt-get -qq install emacs-snapshot-el;
+    fi
+
+# Emacs 23 does not come with ERT.  Download it and have emacs find it
+before_script:
+  - if [ "$EMACS" = 'emacs23' ]; then
+       curl -Os https://raw.githubusercontent.com/ohler/ert/c619b56c5bc6a866e33787489545b87d79973205/lisp/emacs-lisp/ert.el &&
+       export EMACSLOADPATH=$(emacs -batch -eval "(princ (mapconcat 'identity load-path \":\"))") &&
+       export EMACSLOADPATH="$EMACSLOADPATH:$PWD";
+    fi
+
+script:
+  - ./run_rust_emacs_tests.sh
+
+notifications:
+  email: false

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -246,8 +246,8 @@ fn bar() { }" 14 67))
    "/**
  *
  */"
-   8
-   "This is a very very very very very very very long string"
+   7
+   " This is a very very very very very very very long string"
    "/**
  * This is a very very very very
  * very very very long string
@@ -317,8 +317,7 @@ fn foo() {
     /*!
      * this is a nested doc comment
      */
-
-    //! And so is this
+    \n    //! And so is this
 }"))
 
 (ert-deftest indent-inside-braces ()

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -616,7 +616,10 @@ fn indented_already() {
 POS-SYMBOL is a symbol found in `rust-test-positions-alist'.
 Convert the line-column information from that list into a buffer position value."
   (interactive "P")
-  (pcase-let ((`(,line ,column) (cadr (assoc pos-symbol rust-test-positions-alist))))
+  (let* (
+         (line-and-column (cadr (assoc pos-symbol rust-test-positions-alist)))
+         (line (nth 0 line-and-column))
+         (column (nth 1 line-and-column)))
     (save-excursion
       (goto-line line)
       (move-to-column column)
@@ -844,14 +847,14 @@ All positions are position symbols found in `rust-test-positions-alist'."
 (defun rust-test-group-str-by-face (str)
   "Fontify `STR' in rust-mode and group it by face, returning a
 list of substrings of `STR' each followed by its face."
-  (cl-loop with fontified = (rust-test-fontify-string str)
-           for start = 0 then end
-           while start
-           for end   = (next-single-property-change start 'face fontified)
-           for prop  = (get-text-property start 'face fontified)
-           for text  = (substring-no-properties fontified start end)
-           if prop
-           append (list text prop)))
+  (loop with fontified = (rust-test-fontify-string str)
+        for start = 0 then end
+        while start
+        for end   = (next-single-property-change start 'face fontified)
+        for prop  = (get-text-property start 'face fontified)
+        for text  = (substring-no-properties fontified start end)
+        if prop
+        append (list text prop)))
 
 (defun rust-test-font-lock (source face-groups)
   "Test that `SOURCE' fontifies to the expected `FACE-GROUPS'"


### PR DESCRIPTION
There was a bit more to this than I initially expected...

The rust-mode code has a few things in it that show intent to keep it compatible with emacs 23 as well as emacs 24, so the `.travis.yml` file here tests it against emacs 23, 24 and the latest snapshot build.  To make it successfully test on emacs 23 I had to change the test code (though not the actual rust-mode code under test) to eliminate some use of forms that were newly introduced in emacs 24.

The way it installs emacs in the Travis VM is taken from the example at https://github.com/rolandwalker/emacs-travis.  Other repos seem using the same approach as well--a very well known one is [Magit](https://github.com/magit/magit/blob/master/.travis.yml).  

There are a few unfortunate things about it:

  1. The PPA that it uses to get emacs 24 [now proclaims itself deprecated](https://launchpad.net/~cassou/+archive/ubuntu/emacs), although for the time being it still works.
  2. Because it uses apt-get to install emacs, it can't use Travis's new container infrastructure.  The Travis team appears to be working on lifting this limitation, so this seems to be only a temporary problem.

An alternative approach would be to have it download an emacs source tarball right from a GNU mirror, and rebuild emacs from source each time.  That would eliminate dependency on no-longer-interested third parties, but would also complicate the configuration in this repo and might make the travis builds take a while.  (I haven't tried it, so I can't really say for sure.)

Here is [a successful Travis run with this version from my own fork](https://travis-ci.org/MicahChalmer/rust-mode/builds/49408534).