### PR TITLE
Fix tests broken by trailing whitespace removal

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -246,8 +246,8 @@ fn bar() { }" 14 67))
    "/**
  *
  */"
-   8
-   "This is a very very very very very very very long string"
+   7
+   " This is a very very very very very very very long string"
    "/**
  * This is a very very very very
  * very very very long string
@@ -317,8 +317,7 @@ fn foo() {
     /*!
      * this is a nested doc comment
      */
-
-    //! And so is this
+    \n    //! And so is this
 }"))
 
 (ert-deftest indent-inside-braces ()


### PR DESCRIPTION
Commit a8fad0f broke the ERT tests by removing trailing whitespace
inside the test strings.  Fix the tests, and replace some line endings
inside strings with explicit "\n" to avoid having further significant
trailing whitespace in the code.

(Cherry-picked from #2 ... I wanted to get this in now , but I may land the other shortly.)

Fix #19