### PR TITLE
disable emacs23 testing on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: generic
 
 env:
   matrix:
-    - EMACS=emacs23
     - EMACS=emacs24
     - EMACS=emacs-snapshot
 


### PR DESCRIPTION
disable emacs23 testing on travis.

This is to address (indirectly) the travis build failure noted here:

 https://travis-ci.org/rust-lang/rust-mode/jobs/49740311

after posting PR #22