### PR TITLE
Emacs 23 Fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: generic
 
 env:
   matrix:
+    - EMACS=emacs23
     - EMACS=emacs24
     - EMACS=emacs-snapshot
 

--- a/README.md
+++ b/README.md
@@ -76,4 +76,9 @@ the packages for you (under `~/.emacs.d/elpa/`).
 The file `rust-mode-tests.el` contains tests that can be run via
 [ERT](http://www.gnu.org/software/emacs/manual/html_node/ert/index.html).
 You can use `run_rust_emacs_tests.sh` to run them in batch mode, if
-Emacs is somewhere in your `$PATH`.
+you set the environment variable EMACS to a program that runs emacs.
+
+To test it under emacs 23, which does not ship with ERT, download ert.el from
+https://raw.githubusercontent.com/ohler/ert/c619b56c5bc6a866e33787489545b87d79973205/lisp/emacs-lisp/ert.el
+and put it in a place where emacs can find it.  (ERT has shipped with emacs
+since emacs 24.)

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1012,3 +1012,12 @@ fn main() {
 }
 "
    )))
+
+(ert-deftest indent-method-chains-after-comment ()
+  (let ((rust-indent-method-chain t)) (test-indent
+   "
+fn main() { // comment here should not push next line out
+    foo.bar()
+}
+"
+   )))

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -289,7 +289,11 @@ very very very long string
     (rust-test-manip-code
      deindented
      1
-     (lambda () (indent-region 1 (buffer-size)))
+     (lambda ()
+       ;; The indentation will fial in some cases if the syntax properties are
+       ;; not set.  This only happens when font-lock fontifies the buffer.
+       (font-lock-fontify-buffer)
+       (indent-region 1 (buffer-size)))
      indented)))
 
 

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -131,7 +131,7 @@
           ;;
           ((skip-dot-identifier
             (lambda ()
-              (when (looking-back (concat "\." rust-re-ident))
+              (when (looking-back (concat "\\." rust-re-ident))
                 (backward-word 1)
                 (backward-char)
                 (- (current-column) rust-indent-offset)))))


### PR DESCRIPTION
Fix #27 as follows:

  * Fix the character quote handling to work on emacs 23
  * Fix the method chains to work on emacs 23
  * Update the ERT section of the README to show how to get ERT for emacs 23 (and to reflect #21)
  * Re-enable emacs 23 on travis, now that all the tests pass again

Also fixes #28, which was present in all emacs versions (I happened on it while fixing doing the rest of this, then saw that it had been filed as #28 in the meantime.)