### PR TITLE
Fix raw string bugs

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -963,6 +963,54 @@ list of substrings of `STR' each followed by its face."
      "r\"With a backslash at the end\\\"" font-lock-string-face
      "r##\"With two hashes\"##" font-lock-string-face)))
 
+(ert-deftest font-lock-raw-string-with-inner-hash ()
+  (rust-test-font-lock
+   "r##\"I've got an octothorpe (#)\"##; foo()"
+   '("r##\"I've got an octothorpe (#)\"##" font-lock-string-face)))
+
+(ert-deftest font-lock-string-ending-with-r-not-raw-string ()
+  (rust-test-font-lock
+   "fn f() {
+    \"Er\";
+}
+
+fn g() {
+    \"xs\";
+}"
+   '("fn" font-lock-keyword-face
+     "f" font-lock-function-name-face
+     "\"Er\"" font-lock-string-face
+     "fn" font-lock-keyword-face
+     "g" font-lock-function-name-face
+     "\"xs\"" font-lock-string-face)))
+
+(ert-deftest font-lock-raw-string-trick-ending-followed-by-string-with-quote ()
+  (rust-test-font-lock
+   "r\"With what looks like the start of a raw string at the end r#\";
+not_a_string();
+r##\"With \"embedded\" quote \"##;"
+   '("r\"With what looks like the start of a raw string at the end r#\"" font-lock-string-face
+     "r##\"With \"embedded\" quote \"##" font-lock-string-face)))
+
+(ert-deftest font-lock-raw-string-starter-inside-raw-string ()
+  ;; Check that it won't look for a raw string beginning inside another raw string.
+  (rust-test-font-lock
+   "r#\"In the first string r\" in the first string \"#;
+not_in_a_string();
+r##\"In the second string\"##;"
+   '("r#\"In the first string r\" in the first string \"#" font-lock-string-face
+     "r##\"In the second string\"##" font-lock-string-face)))
+
+(ert-deftest font-lock-raw-string-starter-inside-comment ()
+  ;; Check that it won't look for a raw string beginning inside another raw string.
+  (rust-test-font-lock
+   "// r\" this is a comment
+\"this is a string\";
+this_is_not_a_string();)"
+   '("// " font-lock-comment-delimiter-face
+     "r\" this is a comment\n" font-lock-comment-face
+     "\"this is a string\"" font-lock-string-face)))
+
 (ert-deftest indent-method-chains-no-align ()
   (let ((rust-indent-method-chain nil)) (test-indent
    "

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -968,6 +968,11 @@ list of substrings of `STR' each followed by its face."
    "r##\"I've got an octothorpe (#)\"##; foo()"
    '("r##\"I've got an octothorpe (#)\"##" font-lock-string-face)))
 
+(ert-deftest font-lock-raw-string-with-inner-quote-and-hash ()
+  (rust-test-font-lock
+   "not_the_string(); r##\"string \"# still same string\"##; not_the_string()"
+   '("r##\"string \"# still same string\"##" font-lock-string-face)))
+
 (ert-deftest font-lock-string-ending-with-r-not-raw-string ()
   (rust-test-font-lock
    "fn f() {


### PR DESCRIPTION
Fix #34, as well as some other odd cases that could fool the previously landed raw string handling (look in the tests for the details of the edge cases).

While this may look like a lot more code, it's mostly because I've expanded the regexp using the built-in `rx` sexp notation, and commented each piece so that hopefully it can be understood later.  It certainly made it easier for _me_ to work with, especially after I had to make a single regexp cover all raw strings--both with and without `#` characters--to avoid some problems that popped up if I kept it split into two.