### PR TITLE
Fix word and symbol syntax distinction

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -128,7 +128,7 @@
           ((skip-dot-identifier
             (lambda ()
               (when (looking-back (concat "\\." rust-re-ident))
-                (backward-word 1)
+                (forward-thing 'symbol -1)
                 (backward-char)
                 (- (current-column) rust-indent-offset)))))
         (cond

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -32,11 +32,6 @@
     (modify-syntax-entry ?\" "\"" table)
     (modify-syntax-entry ?\\ "\\" table)
 
-    ;; mark _ as a word constituent so that identifiers
-    ;; such as xyz_type don't cause type to be highlighted
-    ;; as a keyword
-    (modify-syntax-entry ?_ "w" table)
-
     ;; Comments
     (modify-syntax-entry ?/  ". 124b" table)
     (modify-syntax-entry ?*  ". 23"   table)
@@ -274,10 +269,10 @@
   (append
    `(
      ;; Keywords proper
-     (,(regexp-opt rust-mode-keywords 'words) . font-lock-keyword-face)
+     (,(regexp-opt rust-mode-keywords 'symbols) . font-lock-keyword-face)
 
      ;; Special types
-     (,(regexp-opt rust-special-types 'words) . font-lock-type-face)
+     (,(regexp-opt rust-special-types 'symbols) . font-lock-type-face)
 
      ;; Attributes like `#[bar(baz)]` or `#![bar(baz)]` or `#[bar = "baz"]`
      (,(rust-re-grab (concat "#\\!?\\[" rust-re-ident "[^]]*\\]"))


### PR DESCRIPTION
By passing 'symbols as 2nd argument to regexp-opt, keywords will not be
erroneously matched inside symbols. This obviates changing the syntax of
`_' to "w".

Fixes https://github.com/rust-lang/rust-mode/issues/41
Fixes #11