### PR TITLE
Indent inside strings after line-ending backslash

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1290,3 +1290,39 @@ And another line not indented
 \")
 }
 "))
+
+(ert-deftest test-indent-string-eol-backslash-dont-touch-raw-strings ()
+  (test-indent
+   "
+pub fn foo() {
+    format!(r\"\
+abc\
+         def\");
+}
+
+pub fn foo() {
+    format!(r\"la la la
+    la\
+la la\");
+}
+"
+   ;; Should still indent the code parts but leave the string internals alone:
+   "
+    pub fn foo() {
+    format!(r\"\
+abc\
+         def\");
+}
+
+pub fn foo() {
+          format!(r\"la la la
+    la\
+la la\");
+}
+"
+   ))
+
+(ert-deftest indent-inside-string-first-line ()
+  (test-indent
+   ;; Needs to leave 1 space before "world"
+   "\"hello \\\n world\""))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -117,7 +117,7 @@
     ;; be undone via tab.
     
     (when (looking-at (concat "\s*\." rust-re-ident))
-      (previous-logical-line)
+      (forward-line -1)
       (end-of-line)
 
       (let
@@ -176,7 +176,7 @@
                    ((string-begin-pos (nth 8 (syntax-ppss)))
                     (end-of-prev-line-pos (when (> (line-number-at-pos) 1)
                                             (save-excursion
-                                              (previous-line)
+                                              (forward-line -1)
                                               (end-of-line)
                                               (point)))))
                  (when

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -164,10 +164,58 @@
                       (when rust-indent-method-chain
                         (rust-align-to-method-chain))
                       (save-excursion
+                        (rust-rewind-irrelevant)
                         (backward-up-list)
                         (rust-rewind-to-beginning-of-current-level-expr)
                         (+ (current-column) rust-indent-offset))))))
              (cond
+              ;; Indent inside a non-raw string only if the the previous line
+              ;; ends with a backslash that is is inside the same string
+              ((nth 3 (syntax-ppss))
+               (let*
+                   ((string-begin-pos (nth 8 (syntax-ppss)))
+                    (end-of-prev-line-pos (when (> (line-number-at-pos) 1)
+                                            (save-excursion
+                                              (previous-line)
+                                              (end-of-line)
+                                              (point)))))
+                 (when
+                     (and
+                      ;; If the string begins with an "r" it's a raw string and
+                      ;; we should not change the indentation
+                      (/= ?r (char-after string-begin-pos))
+
+                      ;; If we're on the first line this will be nil and the
+                      ;; rest does not apply
+                      end-of-prev-line-pos
+
+                      ;; The end of the previous line needs to be inside the
+                      ;; current string...
+                      (> end-of-prev-line-pos string-begin-pos)
+
+                      ;; ...and end with a backslash
+                      (= ?\\ (char-before end-of-prev-line-pos)))
+
+                   ;; Indent to the same level as the previous line, or the
+                   ;; start of the string if the previous line starts the string
+                   (if (= (line-number-at-pos end-of-prev-line-pos) (line-number-at-pos string-begin-pos))
+                       ;; The previous line is the start of the string.
+                       ;; If the backslash is the only character after the
+                       ;; string beginning, indent to the next indent
+                       ;; level.  Otherwise align with the start of the string.
+                       (if (> (- end-of-prev-line-pos string-begin-pos) 2)
+                           (save-excursion
+                             (goto-char (+ 1 string-begin-pos))
+                             (current-column))
+                         baseline)
+
+                     ;; The previous line is not the start of the string, so
+                     ;; match its indentation.
+                     (save-excursion
+                       (goto-char end-of-prev-line-pos)
+                       (back-to-indentation)
+                       (current-column))))))
+              
               ;; A function return type is indented to the corresponding function arguments
               ((looking-at "->")
                (save-excursion
@@ -223,13 +271,14 @@
                     ;; so add one additional indent level
                     (+ baseline rust-indent-offset))))))))))
 
-    ;; If we're at the beginning of the line (before or at the current
-    ;; indentation), jump with the indentation change.  Otherwise, save the
-    ;; excursion so that adding the indentations will leave us at the
-    ;; equivalent position within the line to where we were before.
-    (if (<= (current-column) (current-indentation))
-        (indent-line-to indent)
-      (save-excursion (indent-line-to indent)))))
+    (when indent
+      ;; If we're at the beginning of the line (before or at the current
+      ;; indentation), jump with the indentation change.  Otherwise, save the
+      ;; excursion so that adding the indentations will leave us at the
+      ;; equivalent position within the line to where we were before.
+      (if (<= (current-column) (current-indentation))
+          (indent-line-to indent)
+        (save-excursion (indent-line-to indent))))))
 
 
 ;; Font-locking definitions and helpers


### PR DESCRIPTION
Fix #9.

Note there are a few different ways it tries to determine how to indent a line within a string.  Here are some examples from the tests:

```rust
pub fn aligned_with_str_begin() {
    format!("abc \
             def");
}


pub fn indented_to_next_level() {
    format!("\
        abc \
        def");
}

pub fn arbitrary_indents_with_and_without_backslashes() {
    
    println!("
Here is the beginning of the string
            and here is a line that is arbitrarily indented \
            *and a continuation of that indented line
     and another arbitrary indentation
  still another
        yet another \
        *with a line continuing it
And another line not indented
");

}
```

In the first function, the continuation aligns with the start of the string.  In the second, it pushes out to the next indentation level, since there is nothing in the string on the previous line.  (This is intended to be similar to how it indents lists inside parentheses--aligns to the open paren if there is anything following it on the same line, indent to next level otherwise.)

If the line ending with a backslash is not the first line in the string, the indent level of that line is used to continue it.  In the third function, the indentation will change the whitespace before the lines beginning in `*` in order to align them with their previous lines.  It will leave all the other lines of that string entirely untouched.