### PR TITLE
Make fill-region work correctly in comments

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -42,9 +42,9 @@
              original point-pos manip-func expected (buffer-string)))))
 
 (defun test-fill-paragraph (unfilled expected &optional start-pos end-pos)
-  "We're going to run through many scenarios here--the point should be able to be anywhere from the start-pos (defaults to 1) through end-pos (defaults to the length of what was passed in) and (fill-paragraph) should return the same result.
+  "We're going to run through many scenarios here--the point should be able to be anywhere from the start-pos (defaults to 1) through end-pos (defaults to the length of what was passed in) and (fill-paragraph) should return the same result.  It should also work with fill-region from start-pos to end-pos.
 
-Also, the result should be the same regardless of whether the code is at the beginning or end of the file.  (If you're not careful, that can make a difference.)  So we test each position given above with the passed code at the beginning, the end, neither and both.  So we do this a total of (end-pos - start-pos)*4 times.  Oy."
+Also, the result should be the same regardless of whether the code is at the beginning or end of the file.  (If you're not careful, that can make a difference.)  So we test each position given above with the passed code at the beginning, the end, neither and both.  So we do this a total of 1 + (end-pos - start-pos)*4 times.  Oy."
   (let* ((start-pos (or start-pos 1))
          (end-pos (or end-pos (length unfilled)))
          (padding "\n     \n")
@@ -69,7 +69,16 @@ Also, the result should be the same regardless of whether the code is at the beg
                            (lambda ()
                              (let ((fill-column rust-test-fill-column))
                                (fill-paragraph)))
-                           (concat padding-beginning expected padding-end)))))))
+                           (concat padding-beginning expected padding-end)))))
+    ;; In addition to all the fill-paragraph tests, check that it works using fill-region
+    (rust-test-manip-code
+     unfilled
+     start-pos
+     (lambda ()
+       (let ((fill-column rust-test-fill-column))
+         (fill-region start-pos end-pos)))
+     expected)
+    ))
 
 (ert-deftest fill-paragraph-top-level-multi-line-style-doc-comment-second-line ()
   (test-fill-paragraph
@@ -223,7 +232,7 @@ fn bar() { }"
 /// This is my comment.  This is
 /// more of my comment.  This is
 /// even more.
-fn bar() { }" 14 67))
+fn bar() { }" 14 85))
 
 (defun test-auto-fill (initial position inserted expected)
   (rust-test-manip-code

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -508,7 +508,7 @@
     (funcall body)))
 
 (defun rust-find-fill-prefix ()
-  (rust-with-comment-fill-prefix (lambda () fill-prefix)))
+  (rust-in-comment-paragraph (lambda () (rust-with-comment-fill-prefix (lambda () fill-prefix)))))
 
 (defun rust-fill-paragraph (&rest args)
   "Special wrapping for `fill-paragraph' to handle multi-line comments with a * prefix on each line."
@@ -704,6 +704,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (setq-local fill-paragraph-function 'rust-fill-paragraph)
   (setq-local fill-forward-paragraph-function 'rust-fill-forward-paragraph)
   (setq-local adaptive-fill-function 'rust-find-fill-prefix)
+  (setq-local adaptive-fill-first-line-regexp "")
   (setq-local comment-multi-line t)
   (setq-local comment-line-break-function 'rust-comment-indent-new-line)
   (setq-local imenu-generic-expression rust-imenu-generic-expression)


### PR DESCRIPTION
Fix #15.

One note: the change in the seemingly-unrelated `
fill-paragraph-single-line-style-code-before-and-after` test was to correct the ending of the paragraph to be filled.  I added a test to all the `test-fill-paragraph` tests to try it with `fill-region` on the whole range, but that means that the test will no longer work if the entire paragraph is not specified as the range.  This didn't matter when it was just trying a `fill-paragraph` with no active region at each point, which is why the test could pass before.