### PR TITLE
Use (goto-char (point-max)) instead of (end-of-buffer) to silence warnin...

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -774,7 +774,7 @@ See `compilation-error-regexp-alist for help on their format.")
                         ; start of the buffer: the relevant text
                         ; (shortened url or error message) is exactly
                         ; the last line.
-                        (end-of-buffer)
+                        (goto-char (point-max))
                         (let ((last-line (thing-at-point 'line t))
                               (err (plist-get state :error)))
                           (kill-buffer)


### PR DESCRIPTION
...g.

Fixes issue #54.