### PR TITLE
Match panics during build as compilation warnings

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -752,11 +752,21 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   "Specifications for matching errors in rustc invocations.
 See `compilation-error-regexp-alist for help on their format.")
 
+;; Match test run failures and panics during compilation as
+;; compilation warnings
+(defvar cargo-compilation-regexps
+  '("^\\s-+thread '[^']+' panicked at \\('[^']+', \\([^:]+\\):\\([0-9]+\\)\\)" 2 3 nil nil 1)
+  "Specifications for matching panics in cargo test invocations.
+See `compilation-error-regexp-alist for help on their format.")
+
 (eval-after-load 'compile
   '(progn
      (add-to-list 'compilation-error-regexp-alist-alist
                   (cons 'rustc rustc-compilation-regexps))
-     (add-to-list 'compilation-error-regexp-alist 'rustc)))
+     (add-to-list 'compilation-error-regexp-alist 'rustc)
+     (add-to-list 'compilation-error-regexp-alist-alist
+                  (cons 'cargo cargo-compilation-regexps))
+     (add-to-list 'compilation-error-regexp-alist 'cargo)))
 
 ;;; Functions to submit (parts of) buffers to the rust playpen, for
 ;;; sharing.


### PR DESCRIPTION
Enables using `cargo test` as the compilation command in emacs, and
adds test failures as compilation warnings.