### PR TITLE
Fontifies documentation comments

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1102,6 +1102,25 @@ this_is_not_a_string();)"
      "//! doc */" font-lock-comment-face)))
 
 
+(ert-deftest font-lock-doc-block-comment-parent ()
+  (rust-test-font-lock
+   "/*! doc */"
+   '("/*! doc */" font-lock-doc-face)))
+
+(ert-deftest font-lock-doc-block-comment-item ()
+  (rust-test-font-lock
+   "/** doc */"
+   '("/** doc */" font-lock-doc-face)))
+
+(ert-deftest font-lock-doc-block-in-string ()
+  (rust-test-font-lock
+   "\"/** doc */\""
+   '("\"/** doc */\"" font-lock-string-face))
+  (rust-test-font-lock
+   "\"/*! doc */\""
+   '("\"/*! doc */\"" font-lock-string-face)))
+
+
 
 (ert-deftest indent-method-chains-no-align ()
   (let ((rust-indent-method-chain nil)) (test-indent

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -912,6 +912,7 @@ list of substrings of `STR' each followed by its face."
   (should (equal (rust-test-group-str-by-face source)
                  face-groups)))
 
+
 (ert-deftest font-lock-attribute-simple ()
   (rust-test-font-lock
    "#[foo]"
@@ -1066,6 +1067,41 @@ this_is_not_a_string();)"
    '("// " font-lock-comment-delimiter-face
      "r\" this is a comment\n" font-lock-comment-face
      "\"this is a string\"" font-lock-string-face)))
+
+
+;;; Documentation comments
+
+(ert-deftest font-lock-doc-line-comment-parent ()
+  (rust-test-font-lock
+   "//! doc"
+   '("//! doc" font-lock-doc-face)))
+
+(ert-deftest font-lock-doc-line-comment-item ()
+  (rust-test-font-lock
+   "/// doc"
+   '("/// doc" font-lock-doc-face)))
+
+(ert-deftest font-lock-doc-line-in-string ()
+  (rust-test-font-lock
+   "\"/// doc\""
+   '("\"/// doc\"" font-lock-string-face))
+
+  (rust-test-font-lock
+   "\"//! doc\""
+   '("\"//! doc\"" font-lock-string-face)))
+
+(ert-deftest font-lock-doc-line-in-nested-comment ()
+  (rust-test-font-lock
+   "/* /// doc */"
+   '("/* " font-lock-comment-delimiter-face
+     "/// doc */" font-lock-comment-face))
+
+  (rust-test-font-lock
+   "/* //! doc */"
+   '("/* " font-lock-comment-delimiter-face
+     "//! doc */" font-lock-comment-face)))
+
+
 
 (ert-deftest indent-method-chains-no-align ()
   (let ((rust-indent-method-chain nil)) (test-indent

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -10,8 +10,10 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'misc)
-                   (require 'rx))
+(eval-when-compile
+  (require 'misc)
+  (require 'rx)
+  (require 'cl))
 
 ;; for GNU Emacs < 24.3
 (eval-when-compile
@@ -386,12 +388,12 @@
   ;; whole comment will be.
   (let ((start font-lock-beg)
         (end font-lock-end))
-    (cl-loop for level = (syntax-ppss start)
-             while (and (integerp level) (plusp start))
-             do (decf start))
-    (cl-loop for level = (syntax-ppss end)
-             while (and (integerp level) (plusp end))
-             do (incf end))
+    (loop for level = (syntax-ppss start)
+	  while (and (integerp level) (plusp start))
+	  do (decf start))
+    (loop for level = (syntax-ppss end)
+	  while (and (integerp level) (plusp end))
+	  do (incf end))
     (unless (and (eql start font-lock-beg) (eql end font-lock-end))
       (setq font-lock-beg start)
       (setq font-lock-end end)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -399,14 +399,14 @@
   
 
 (defun rust-look-for-line-doc-comment (bound)
-  ;; Find documentation comments starging with //! or ///. It will
+  ;; Find documentation comments starting with //! or ///. It will
   ;; only match it if it is inside a non-nestable comment.
   (when (search-forward-regexp "//[!/].*" bound t)
     (eq (nth 4 (syntax-ppss)) t)))
 
 
 (defun rust-look-for-block-doc-comment (bound)
-  ;; Find documentation comments starging with /** or /*!. The
+  ;; Find documentation comments starting with /** or /*!. The
   ;; function `rust-extend-region-nested-comment' is invoked by
   ;; font-lock in order to ensure that no partial comment is between
   ;; the point and BOUND.

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -360,7 +360,9 @@
 
      ;; CamelCase Means Type Or Constructor
      (,(rust-re-grabword rust-re-CamelCase) 1 font-lock-type-face)
-     )
+
+     ;; Documentation line comments
+     (rust-look-for-doc-comment 0 font-lock-doc-face t))
 
    ;; Item definitions
    (mapcar #'(lambda (x)
@@ -373,6 +375,14 @@
              ("use" . font-lock-type-face)
              ("fn" . font-lock-function-name-face)
              ("static" . font-lock-constant-face)))))
+
+
+(defun rust-look-for-doc-comment (bound)
+  ;; Find documentation comments starging with //! or ///. It will
+  ;; only match it if it is inside a non-nestable comment.
+  (when (search-forward-regexp "//[!/].*" bound t)
+    (eq (nth 4 (syntax-ppss)) t)))
+
 
 (defun rust-look-for-raw-string (bound)
   ;; Find a raw string, but only if it's not in the middle of another string or
@@ -430,6 +440,7 @@
       (goto-char (nth 3 ret-list))
       (set-match-data (nth 2 ret-list))
       (nth 0 ret-list))))
+
 
 (defvar rust-mode-font-lock-syntactic-keywords
   (append


### PR DESCRIPTION
I have implemented fontification of both line (/// and //!) and block (/** and /*!) comments. It uses the `font-lock-doc-face`, which does not look very pretty in some themes. We could change this if necessary. It includes unit tests and it fixes #61.

See a couple of screenshots:

![example](https://cloud.githubusercontent.com/assets/265168/7690736/7d8d088e-fdb6-11e4-8274-17e09608b776.PNG)

![test](https://cloud.githubusercontent.com/assets/265168/7690737/7da0ae5c-fdb6-11e4-974b-8d582769e200.PNG)

