### PR TITLE
handle case where blink-matching-paren-distance is nil

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -639,7 +639,8 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
               ;; didn't find a match
               (> angle-brackets 0)
               ;; we have no guarantee of a match, so give up eventually
-              (< (- start-point (point)) blink-matching-paren-distance)
+	      (or (not blink-matching-paren-distance)
+		  (< (- start-point (point)) blink-matching-paren-distance))
               ;; didn't hit the top of the buffer
               (> (point) (point-min))
               ;; didn't hit something else weird like a `;`


### PR DESCRIPTION
If blink-matching-paren-distance is nil -- a valid value -- then rust-find-matching-angle-bracket will error.