### PR TITLE
rename rust-matching-angle-bracker-timer to rust-matching-angle-bracket-timer

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -628,7 +628,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
 
 (defvar rust-point-before-matching-angle-bracket 0)
 
-(defvar rust-matching-angle-bracker-timer nil)
+(defvar rust-matching-angle-bracket-timer nil)
 
 (defun rust-find-matching-angle-bracket ()
   (save-excursion
@@ -659,9 +659,9 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
 
 (defun rust-restore-point-after-angle-bracket ()
   (goto-char rust-point-before-matching-angle-bracket)
-  (when rust-matching-angle-bracker-timer
-    (cancel-timer rust-matching-angle-bracker-timer))
-  (setq rust-matching-angle-bracker-timer nil)
+  (when rust-matching-angle-bracket-timer
+    (cancel-timer rust-matching-angle-bracket-timer))
+  (setq rust-matching-angle-bracket-timer nil)
   (remove-hook 'pre-command-hook 'rust-restore-point-after-angle-bracket))
 
 (defun rust-match-angle-bracket-hook ()
@@ -677,7 +677,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
           (setq rust-point-before-matching-angle-bracket (point))
           (goto-char matching-angle-bracket-point)
           (add-hook 'pre-command-hook 'rust-restore-point-after-angle-bracket)
-          (setq rust-matching-angle-bracker-timer
+          (setq rust-matching-angle-bracket-timer
                 (run-at-time blink-matching-delay nil 'rust-restore-point-after-angle-bracket)))))))
 
 (defun rust-match-angle-bracket ()


### PR DESCRIPTION
This corrects a typo in a variable name.