### PR TITLE
remove rust-mode-character-literal-syntax-table

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -40,13 +40,6 @@
 
     table))
 
-(defvar rust-mode-character-literal-syntax-table
-  (let ((table (make-syntax-table rust-mode-syntax-table)))
-    (modify-syntax-entry ?' "\"" table)
-    (modify-syntax-entry ?\" "_" table)
-
-    table))
-
 (defgroup rust-mode nil
   "Support for Rust code."
   :link '(url-link "http://www.rust-lang.org/")


### PR DESCRIPTION
Fix #53 
This removes an unused variable.