### PR TITLE
Distinguish face for doc-comments

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1085,6 +1085,70 @@ this_is_not_a_string();)"
     (should (equal nil (get-text-property 28 'face))) ;; Semicolon--should not be part of the string
     ))
 
+;;; Documentation comments
+
+(ert-deftest font-lock-doc-line-comment-parent ()
+  (rust-test-font-lock
+   "//! doc"
+   '("//! doc" font-lock-doc-face)))
+
+(ert-deftest font-lock-doc-line-comment-item ()
+  (rust-test-font-lock
+   "/// doc"
+   '("/// doc" font-lock-doc-face)))
+
+(ert-deftest font-lock-nondoc-line ()
+  (rust-test-font-lock
+   "////// doc"
+   '("////// " font-lock-comment-delimiter-face
+     "doc" font-lock-comment-face)))
+
+(ert-deftest font-lock-doc-line-in-string ()
+  (rust-test-font-lock
+   "\"/// doc\""
+   '("\"/// doc\"" font-lock-string-face))
+
+  (rust-test-font-lock
+   "\"//! doc\""
+   '("\"//! doc\"" font-lock-string-face)))
+
+(ert-deftest font-lock-doc-line-in-nested-comment ()
+  (rust-test-font-lock
+   "/* /// doc */"
+   '("/* " font-lock-comment-delimiter-face
+     "/// doc */" font-lock-comment-face))
+
+  (rust-test-font-lock
+   "/* //! doc */"
+   '("/* " font-lock-comment-delimiter-face
+     "//! doc */" font-lock-comment-face)))
+
+
+(ert-deftest font-lock-doc-block-comment-parent ()
+  (rust-test-font-lock
+   "/*! doc */"
+   '("/*! doc */" font-lock-doc-face)))
+
+(ert-deftest font-lock-doc-block-comment-item ()
+  (rust-test-font-lock
+   "/** doc */"
+   '("/** doc */" font-lock-doc-face)))
+
+(ert-deftest font-lock-nondoc-block-comment-item ()
+  (rust-test-font-lock
+   "/***** doc */"
+   '("/**" font-lock-comment-delimiter-face
+     "*** doc */" font-lock-comment-face)))
+
+(ert-deftest font-lock-doc-block-in-string ()
+  (rust-test-font-lock
+   "\"/** doc */\""
+   '("\"/** doc */\"" font-lock-string-face))
+  (rust-test-font-lock
+   "\"/*! doc */\""
+   '("\"/*! doc */\"" font-lock-string-face)))
+
+
 (ert-deftest indent-method-chains-no-align ()
   (let ((rust-indent-method-chain nil)) (test-indent
    "

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -480,6 +480,16 @@
    ;; Handle raw strings:
    `((rust-look-for-raw-string (1 "|") (4 "_" nil t) (5 "|" nil t) (6 "|" nil t)))))
 
+(defun rust-mode-syntactic-face-function (state)
+  "Syntactic face function to distinguish doc comments from other comments."
+  (if (nth 3 state) 'font-lock-string-face
+    (save-excursion
+      (goto-char (nth 8 state))
+      (if (looking-at "/\\([*][*!][^*!]\\|/[/!][^/!]\\)")
+          'font-lock-doc-face
+        'font-lock-comment-face
+    ))))
+
 (defun rust-fill-prefix-for-comment-start (line-start)
   "Determine what to use for `fill-prefix' based on what is at the beginning of a line."
   (let ((result
@@ -740,7 +750,11 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
 
   ;; Fonts
   (add-to-list 'font-lock-extend-region-functions 'rust-extend-region-raw-string)
-  (setq-local font-lock-defaults '(rust-mode-font-lock-keywords nil nil nil nil (font-lock-syntactic-keywords . rust-mode-font-lock-syntactic-keywords)))
+  (setq-local font-lock-defaults '(rust-mode-font-lock-keywords
+                                   nil nil nil nil
+                                   (font-lock-syntactic-keywords . rust-mode-font-lock-syntactic-keywords)
+                                   (font-lock-syntactic-face-function . rust-mode-syntactic-face-function)
+                                   ))
 
   ;; Misc
   (setq-local comment-start "// ")


### PR DESCRIPTION
Using the syntactic-face-function, we can assign the proper
`font-lock-doc-face' to doc comments ("///" and "//!").