### PR TITLE
Match angle brackets syntactically

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -362,6 +362,29 @@ use foo::bar::baz;
 fn foo() { }
 "))
 
+(ert-deftest font-lock-multi-raw-strings-in-a-row ()
+  (rust-test-font-lock
+   "
+r\"foo\\\", \"bar\", r\"bar\";
+r\"foo\\.\", \"bar\", r\"bar\";
+r\"foo\\..\", \"bar\", r\"foo\\..\\bar\";
+r\"\\\", \"foo\", r\"\\foo\";
+not_a_string();
+
+"
+
+   (apply 'append (mapcar (lambda (s) (list s 'font-lock-string-face))
+                          '("r\"foo\\\"" "\"bar\"" "r\"bar\""
+                            "r\"foo\\.\"" "\"bar\"" "r\"bar\""
+                            "r\"foo\\..\"" "\"bar\"" "r\"foo\\..\\bar\""
+                            "r\"\\\"" "\"foo\"" "r\"\\foo\"")))
+   ))
+
+(ert-deftest font-lock-raw-string-after-normal-string-ending-in-r ()
+  (rust-test-font-lock
+   "\"bar\" r\"foo\""
+   '("\"bar\"" font-lock-string-face "r\"foo\"" font-lock-string-face)))
+
 (ert-deftest indent-params-no-align ()
   (test-indent
    "


### PR DESCRIPTION
Remove the angle bracket blinking feature, and make it actually match `<` and `>` characters as parens in the syntax table instead.  This matching is suppressed as needed, so that less-than and greater-than operators, arrow operators, etc don't throw off the matches.

This has the following effects:

  * Angle brackets match like other braces/parens however they are configured, rather than blinking in a different way.
  * Movement commands like `forward-sexp` and `backward-up-list` acknowledge angle brackets.
  * `electric-pair-mode` works with angle brackets (also suppressed when needed.)
  * Fix #50 - angle brackets are matched in the right pairs; `->` and other non-angle-bracket `<` and `>` characters do not attempt to match.
  * Fix #10 - multi-line lists inside angle brackets are indented like other lists.

Macros have arbitrary syntax and therefore it's not possible to know whether a `<` or `>` character is an angle bracket or not.  So the matching is always suppressed inside macro definitions and uses.

There are a few disadvantages: besides the fact that the code is rather hairy, it also has to detect the non-angle-brackets perfectly, or else it throws off the indentation for the whole rest of the file.  For that reason there is still a custom variable available to disable it (though with a different name than the previous one.)

Having said that, I don't know of any cases where it gets it wrong.  I tested it with [this program](https://gist.github.com/MicahChalmer/1ac9f8de543655e577a1), which compares what emacs thinks are the non-bracket `<`/`>` characters with what the rust compiler thinks.  It passed for all of the rust compiler code base, as well as all the rust code in servo and as many of servo's dependencies as still compile with the latest nightly.

Also included are some bug fixes for some edge case issues in the handling of raw strings and character literals.  I found these while running the test script.  Even if the angle bracket matching itself is deemed to be too risky or hairy to be merged (and I would understand it if that turns out to be the case), you may want to merge the other commits for the bug fixes.  I've put them first to make this easy.

If this PR is accepted, close #66 (because the variable that it renames has been removed entirely) and close #74 (because post-self-insert-hook is no longer used at all.)  Both of these pertain to the old angle bracket blinking code that this PR removes entirely.

And if the PR is not accepted - hey, I still had fun writing it.