### PR TITLE
Remove unnecessary code with call to undefined function

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2168,6 +2168,35 @@ type Foo<T> where T: Copy = Box<T>;
      '((10 11))
      '(7 9))))
 
+
+(ert-deftest font-lock-extend-region-in-string ()
+  
+  (with-temp-buffer
+    (rust-mode)
+    (insert "
+fn foo() {
+    let x = r\"
+Fontification needs to include this whole string or none of it.
+             \"
+}")
+    (font-lock-fontify-buffer)
+    (let ((font-lock-beg 13)
+          (font-lock-end 42))
+      (rust-font-lock-extend-region)
+      (should (<= font-lock-beg 13))
+      (should (>= font-lock-end 106))
+      )
+    (let ((font-lock-beg 42)
+          (font-lock-end 108))
+      (rust-font-lock-extend-region)
+      (should (<= font-lock-beg 25))
+      (should (>= font-lock-end 108)))
+    (let ((font-lock-beg 1)
+          (font-lock-end 12))
+      (rust-font-lock-extend-region)
+      (should (<= font-lock-beg 1))
+      (should (>= font-lock-end 12)))))
+
 ;; If electric-pair-mode is available, load it and run the tests that use it.  If not,
 ;; no error--the tests will be skipped.
 (require 'elec-pair nil t)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -459,14 +459,6 @@
             (goto-char (nth 8 end-ppss))
             (ignore-errors (forward-sexp))
             (setq font-lock-end (max font-lock-end (point)))))
-        
-        ;; If we have the beginning of a raw string in the region, make sure we have the end of
-        ;; it.
-        (when (or beg-in-str end-in-str)
-          (save-excursion
-            (goto-char font-lock-beg)
-            (while (and (< (point) font-lock-end) (ignore-errors (rust-look-for-raw-string (buffer-end 1)))))
-            (setq font-lock-end (max font-lock-end (point)))))
         )))
 
     (or (/= font-lock-beg orig-beg)


### PR DESCRIPTION
Fix #80.  (Oops!)

The piece of code that tries to call the undefined function is entirely unnecessary now.  It was there in an earlier version that didn't have the check to extend to the whole buffer if syntactic fontification wasn't done.  As long as that's done already, then the syntax-based checks to extend out of strings cover raw strings as well.

An adapted version of the test for the extend function that @tromey added in #77 is included here to verify this.