### PR TITLE
Cache (regexp-opt rust-special-types 'symbols) in rust-is-lt-char-operator

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -378,6 +378,7 @@
 ;; newer Emacs versions, but will work on Emacs 23.)
 (defun regexp-opt-symbols (words)
   (concat "\\_<" (regexp-opt words t) "\\_>"))
+(defconst rust-re-special-types (regexp-opt-symbols rust-special-types))
 
 (defvar rust-mode-font-lock-keywords
   (append
@@ -851,7 +852,7 @@
         (or
          ;; The special types can't take type param lists, so a < after one is
          ;; always an operator
-         (looking-at (regexp-opt rust-special-types 'symbols))
+         (looking-at rust-re-special-types)
          
          (rust-is-in-expression-context 'ident)))
 


### PR DESCRIPTION
regexp-opt is generally intended to be cached, and the extra GC was
causing noticeable lag when typing sometimes.

I still get lag in some cases from rust-in-macro calling syntax-ppss and falling through to parse-partial-sexp all the time, but fixing that in a not-horrible way is less trivial.