### PR TITLE
Remove unused require of misc.el

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -10,8 +10,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'misc)
-                   (require 'rx)
+(eval-when-compile (require 'rx)
                    (require 'compile)
                    (require 'url-vars))
 


### PR DESCRIPTION
Fix #95. I don't know what exactly it is that causes the issue, since as far as I know `misc.el` is provided with the version of emacs that people are seeing the issue #95 in.  But requiring it in `rust-mode.el` is no longer needed, and it's causing some people problems, so let's get rid of it.