### PR TITLE
Highlight the unsafe keyword

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -173,6 +173,11 @@
   :safe #'booleanp
   :group 'rust-mode)
 
+(defface rust-unsafe-face
+  '((t :inherit font-lock-warning-face))
+  "Face for the `unsafe' keyword."
+  :group 'rust-mode)
+
 (defun rust-paren-level () (nth 0 (syntax-ppss)))
 (defun rust-in-str-or-cmnt () (nth 8 (syntax-ppss)))
 (defun rust-rewind-past-str-cmnt () (goto-char (nth 8 (syntax-ppss))))
@@ -414,7 +419,7 @@
     "ref" "return"
     "self" "static" "struct" "super"
     "true" "trait" "type"
-    "unsafe" "use"
+    "use"
     "virtual"
     "where" "while"))
 
@@ -454,6 +459,9 @@
 
      ;; Special types
      (,(regexp-opt-symbols rust-special-types) . font-lock-type-face)
+
+     ;; The unsafe keyword
+     ("\\_<unsafe\\_>" . 'rust-unsafe-face)
 
      ;; Attributes like `#[bar(baz)]` or `#![bar(baz)]` or `#[bar = "baz"]`
      (,(rust-re-grab (concat "#\\!?\\[" rust-re-ident "[^]]*\\]"))


### PR DESCRIPTION
As suggested by a recent [Reddit thread](https://www.reddit.com/r/rust/comments/3u9wxu/tip_use_a_special_color_for_the_unsafe_keyword/).

I've added a custom face (`rust-unsafe-face`) that inherits from `font-lock-warning-face` for easy customisation.
