### PR TITLE
Correctly indent where clauses

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -443,6 +443,166 @@ fn foo4(a:int,
 }
 "))
 
+(ert-deftest indent-body-after-where ()
+  (test-indent
+   "
+fn foo1(a: A, b: B) -> A
+    where A: Clone + Default, B: Eq {
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+
+fn foo2(a: A, b: B) -> A
+    where A: Clone + Default, B: Eq
+{
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
+(ert-deftest indent-align-where-clauses-style1a ()
+  (test-indent
+   "
+fn foo1a(a: A, b: B, c: C) -> D
+    where A: Clone + Default,
+          B: Eq,
+          C: PartialEq,
+          D: PartialEq {
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
+(ert-deftest indent-align-where-clauses-style1b ()
+  (test-indent
+   "
+fn foo1b(a: A, b: B, c: C) -> D
+    where A: Clone + Default,
+          B: Eq,
+          C: PartialEq,
+          D: PartialEq
+{
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
+(ert-deftest indent-align-where-clauses-style2a ()
+  (test-indent
+   "
+fn foo2a(a: A, b: B, c: C) -> D where A: Clone + Default,
+                                      B: Eq,
+                                      C: PartialEq,
+                                      D: PartialEq {
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
+(ert-deftest indent-align-where-clauses-style2b ()
+  (test-indent
+   "
+fn foo2b(a: A, b: B, c: C) -> D where A: Clone + Default,
+                                      B: Eq,
+                                      C: PartialEq,
+                                      D: PartialEq
+{
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
+(ert-deftest indent-align-where-clauses-style3a ()
+  (test-indent
+   "
+fn foo3a(a: A, b: B, c: C) -> D where
+    A: Clone + Default,
+    B: Eq,
+    C: PartialEq,
+    D: PartialEq {
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
+(ert-deftest indent-align-where-clauses-style3b ()
+  (test-indent
+   "
+fn foo3b(a: A, b: B, c: C) -> D where
+    A: Clone + Default,
+    B: Eq,
+    C: PartialEq,
+    D: PartialEq
+{
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
+(ert-deftest indent-align-where-clauses-style4a ()
+  (let ((rust-indent-where-clause nil))
+    (test-indent
+     "
+fn foo4a(a: A, b: B, c: C) -> D
+where A: Clone + Default,
+      B: Eq,
+      C: PartialEq,
+      D: PartialEq {
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+")))
+
+(ert-deftest indent-align-where-clauses-style4b ()
+  (let ((rust-indent-where-clause nil))
+    (test-indent
+     "
+fn foo4b(a: A, b: B, c: C) -> D
+where A: Clone + Default,
+      B: Eq,
+      C: PartialEq,
+      D: PartialEq
+{
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+")))
+
+(ert-deftest indent-align-where-clauses-impl-example ()
+  (test-indent
+   "
+impl<'a, K, Q: ?Sized, V, S> Index<&'a Q> for HashMap<K, V, S>
+    where K: Eq + Hash + Borrow<Q>,
+          Q: Eq + Hash,
+          S: HashState,
+{
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
 (ert-deftest indent-square-bracket-alignment ()
   (test-indent
    "

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -603,6 +603,17 @@ impl<'a, K, Q: ?Sized, V, S> Index<&'a Q> for HashMap<K, V, S>
 }
 "))
 
+(ert-deftest indent-align-where-clauses-first-line ()
+  (test-indent
+   "fn foo1(a: A, b: B) -> A
+    where A: Clone + Default, B: Eq {
+    let body;
+    Foo {
+        bar: 3
+    }
+}
+"))
+
 (ert-deftest indent-square-bracket-alignment ()
   (test-indent
    "

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -444,10 +444,11 @@ function or trait.  When nil, where will be aligned with fn or trait."
 
                        (save-excursion
                          (rust-rewind-irrelevant)
-                         ;; Point is now at the end of the previous ine
+                         ;; Point is now at the end of the previous line
                          (or
-                          ;; If we are at the first line, no indentation is needed, so stay at baseline...
-                          (= 1 (line-number-at-pos (point)))
+                          ;; If we are at the start of the buffer, no
+                          ;; indentation is needed, so stay at baseline...
+                          (= (point) 1)
                           ;; ..or if the previous line ends with any of these:
                           ;;     { ? : ( , ; [ }
                           ;; then we are at the beginning of an expression, so stay on the baseline...

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -157,6 +157,13 @@
   :group 'rust-mode
   :safe #'booleanp)
 
+(defcustom rust-indent-where-clause t
+  "Indent the line starting with the where keyword following a
+function or trait.  When nil, where will be aligned with fn or trait."
+  :type 'boolean
+  :group 'rust-mode
+  :safe #'booleanp)
+
 (defcustom rust-playpen-url-format "https://play.rust-lang.org/?code=%s"
   "Format string to use when submitting code to the playpen"
   :type 'string
@@ -213,7 +220,25 @@
       (back-to-indentation))
     (while (> (rust-paren-level) current-level)
       (backward-up-list)
-      (back-to-indentation))))
+      (back-to-indentation))
+    ;; When we're in the where clause, skip over it.  First find out the start
+    ;; of the function and its paren level.
+    (let ((function-start nil) (function-level nil))
+      (save-excursion
+        (rust-beginning-of-defun)
+        (back-to-indentation)
+        ;; Avoid using multiple-value-bind
+        (setq function-start (point)
+              function-level (rust-paren-level)))
+      ;; On a where clause
+      (when (or (looking-at "\\bwhere\\b")
+                ;; or in one of the following lines, e.g.
+                ;; where A: Eq
+                ;;       B: Hash <- on this line
+                (and (save-excursion
+                       (re-search-backward "\\bwhere\\b" function-start t))
+                     (= current-level function-level)))
+        (goto-char function-start)))))
 
 (defun rust-align-to-method-chain ()
   (save-excursion
@@ -348,6 +373,11 @@
               ((and (nth 4 (syntax-ppss)) (looking-at "*"))
                (+ 1 baseline))
 
+              ;; When the user chose not to indent the start of the where
+              ;; clause, put it on the baseline.
+              ((and (not rust-indent-where-clause) (looking-at "\\bwhere\\b"))
+               baseline)
+
               ;; If we're in any other token-tree / sexp, then:
               (t
                (or
@@ -360,6 +390,47 @@
                     (backward-up-list)
                     ;; Point is now at the beginning of the containing set of braces
                     (rust-align-to-expr-after-brace)))
+
+                ;; When where-clauses are spread over multiple lines, clauses
+                ;; should be aligned on the type parameters.  In this case we
+                ;; take care of the second and following clauses (the ones
+                ;; that don't start with "where ")
+                (save-excursion
+                  ;; Find the start of the function, we'll use this to limit
+                  ;; our search for "where ".
+                  (let ((function-start nil) (function-level nil))
+                    (save-excursion
+                      (rust-beginning-of-defun)
+                      (back-to-indentation)
+                      ;; Avoid using multiple-value-bind
+                      (setq function-start (point)
+                            function-level (rust-paren-level)))
+                    ;; When we're not on a line starting with "where ", but
+                    ;; still on a where-clause line, go to "where "
+                    (when (and
+                           (not (looking-at "\\bwhere\\b"))
+                           ;; We're looking at something like "F: ..."
+                           (and (looking-at (concat rust-re-ident ":"))
+                                ;; There is a "where " somewhere after the
+                                ;; start of the function.
+                                (re-search-backward "\\bwhere\\b"
+                                                    function-start t)
+                                ;; Make sure we're not inside the function
+                                ;; already (e.g. initializing a struct) by
+                                ;; checking we are the same level.
+                                (= function-level level)))
+                      ;; skip over "where"
+                      (forward-char 5)
+                      ;; Unless "where" is at the end of the line
+                      (if (eolp)
+                          ;; in this case the type parameters bounds are just
+                          ;; indented once
+                          (+ baseline rust-indent-offset)
+                        ;; otherwise, skip over whitespace,
+                        (skip-chars-forward "[:space:]")
+                        ;; get the column of the type parameter and use that
+                        ;; as indentation offset
+                        (current-column)))))
 
                 (progn
                   (back-to-indentation)


### PR DESCRIPTION
Revisit #82. Now rustfmt has a default style for `where` clauses, it
makes sense to let rust-mode support it by default. How rust-mode
currently indents `where` clauses is totally broken anyway. The line
starting with `where` itself, the following lines that are part of the
`where` clause, and the body were all indented incorrectly. This commit
fixes this.

**Note that this commit does not prescribe a certain indentation style
for where clauses, but supports the most common ones, including
rustfmt's default.**

By choosing the location of (1) `where` and (2) the type parameter
bounds, the user can follow three major indentation styles. There is no
need for a configuration option to choose the style, as the locations of
1 and 2 dictate the style to follow. So all three styles can be used
together in the same file.

For each major style, the opening brace can be on the last line of the
type parameter bounds or on a new line (a or b in the examples). All 6
styles are supported without having to change any configuration option.
See the examples below and the new test cases.

There is one more style that is unfortunately incompatible with the
default `where` indentation style of rustfmt: when the user does not
want `where` to be indented, but aligned with the `fn` or `trait` on the
line before (see examples `foo4a` and `foo4b` below). To enable this
style, the user has to set the new option `rust-indent-where-clause` to
nil (it defaults to t).

Putting `where` and the type parameter bounds on the same line as the
function header is still supported of course (see examples `fooa` and
`foob` below). As there is no indentation, this commit does not
influence this.

Note that rust-mode's indentation has a different goal than rustfmt.
rustfmt reflows code, adds or removes line breaks, reindents, etc.
rust-mode's indentation only indents lines. The goal is not to imitate
rustfmt, but after running rustfmt on a file, reindenting it with
rust-mode should be idempotent. This way, users do not have to deal with
the eternal battle of differing indentation styles of rustfmt and
rust-mode.

The supported styles:

```rust
fn foo1a(a: A, b: B) -> C
    where A: Clone + Default,
          B: Eq,
          C: PartialEq {
    let body;
}

fn foo1b(a: A, b: B) -> C
    where A: Clone + Default,
          B: Eq,
          C: PartialEq
{
    let body;
}
```

```rust
fn foo2a(a: A, b: B) -> C where A: Clone + Default,
                                B: Eq,
                                C: PartialEq {
    let body;
}

fn foo2b(a: A, b: B) -> C where A: Clone + Default,
                                B: Eq,
                                C: PartialEq
{
    let body;
}
```

```rust
fn foo3a(a: A, b: B) -> C where
    A: Clone + Default,
    B: Eq,
    C: PartialEq {
    let body;
}

fn foo3b(a: A, b: B) -> C where
    A: Clone + Default,
    B: Eq,
    C: PartialEq
{
    let body;
}
```

If the user wants `foo4` instead of `foo1`, `rust-indent-where-clause`
must be set to nil. `foo2` and `foo3` are not influenced by this.

```rust
fn foo4a(a: A, b: B) -> C
where A: Clone + Default,
      B: Eq,
      C: PartialEq {
    let body;
}

fn foo4a(a: A, b: B) -> C
where A: Clone + Default,
      B: Eq,
      C: PartialEq
{
    let body;
}
```

Unchanged:

```rust
fn fooa(a: A, b: B) -> C where A: Clone + Default, ... {
    let body;
}

fn foob(a: A, b: B) -> C where A: Clone + Default, ...
{
    let body;
}
```