### PR TITLE
Fix type annotations incorrectly highlighted as modules.

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1403,6 +1403,17 @@ this_is_not_a_string();)"
    "\"/*! doc */\""
    '("\"/*! doc */\"" font-lock-string-face)))
 
+(ert-deftest font-lock-module ()
+  (rust-test-font-lock
+   "foo::bar"
+   '("foo::" font-lock-type-face)))
+
+(ert-deftest font-lock-type-annotation ()
+  "Ensure type annotations are not confused with modules."
+  (rust-test-font-lock
+   "parse::<i32>();"
+   ;; Only the i32 should have been highlighted.
+   '("i32" font-lock-type-face)))
 
 (ert-deftest indent-method-chains-no-align ()
   (let ((rust-indent-method-chain nil)) (test-indent

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -549,7 +549,8 @@ function or trait.  When nil, where will be aligned with fn or trait."
      (,(concat (rust-re-grab rust-re-ident) ":[^:]") 1 font-lock-variable-name-face)
 
      ;; Module names like `foo::`, highlight including the ::
-     (,(rust-re-grab (concat rust-re-ident "::")) 1 font-lock-type-face)
+     ;; but ignore type annotations like foo::<i32>
+     (,(concat (rust-re-grab (concat rust-re-ident "::")) "[^<]") 1 font-lock-type-face)
 
      ;; Lifetimes like `'foo`
      (,(concat "'" (rust-re-grab rust-re-ident) "[^']") 1 font-lock-variable-name-face)


### PR DESCRIPTION
Previously, we were always treating `::` as a module, but Rust
allows type annotations using `::` e.g.

    parse::<i32>();