### PR TITLE
Fix type annotations incorrectly highlighted as modules.

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1403,6 +1403,27 @@ this_is_not_a_string();)"
    "\"/*! doc */\""
    '("\"/*! doc */\"" font-lock-string-face)))
 
+(ert-deftest font-lock-module ()
+  (rust-test-font-lock
+   "foo::bar"
+   '("foo" font-lock-type-face)))
+
+(ert-deftest font-lock-submodule ()
+  (rust-test-font-lock
+   "foo::bar::baz"
+   '("foo" font-lock-type-face
+     "bar" font-lock-type-face)))
+
+(ert-deftest font-lock-type-annotation ()
+  "Ensure type annotations are not confused with modules."
+  (rust-test-font-lock
+   "parse::<i32>();"
+   ;; Only the i32 should have been highlighted.
+   '("i32" font-lock-type-face))
+  (rust-test-font-lock
+   "foo:: <i32>"
+   ;; Only the i32 should have been highlighted.
+   '("i32" font-lock-type-face)))
 
 (ert-deftest indent-method-chains-no-align ()
   (let ((rust-indent-method-chain nil)) (test-indent


### PR DESCRIPTION
Previously, we were always treating `::` as a module, but Rust
allows type annotations using `::` e.g.

    parse::<i32>();

This also changes module highlighting so that only the module name is
highlighted, excluding the `::`. This makes rust-mode consistent with
other Emacs modes, such as c++-mode and ruby-mode.

Before:

![rust_before](https://cloud.githubusercontent.com/assets/70800/12070879/af06707a-b086-11e5-97ab-64b9eb1b8363.png)

After:

![rust_after](https://cloud.githubusercontent.com/assets/70800/12070882/c0932fb8-b086-11e5-9097-6fa8e4bfa677.png)