### PR TITLE
Fix indentation of closing delimiters

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -631,6 +631,25 @@ fn args_on_the_next_line( // with a comment
 }
 "))
 
+(ert-deftest indent-closing-square-bracket ()
+  (test-indent
+   "fn blergh() {
+    let list = vec![
+        1,
+        2,
+        3,
+    ];
+}"))
+
+(ert-deftest indent-closing-paren ()
+  (test-indent
+   "fn blergh() {
+    call(
+        a,
+        function
+    );
+}"))
+
 (ert-deftest indent-nested-fns ()
   (test-indent
    "

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -373,7 +373,7 @@ function or trait.  When nil, where will be aligned with fn or trait."
                      (+ baseline rust-indent-offset))))
 
               ;; A closing brace is 1 level unindented
-              ((looking-at "}") (- baseline rust-indent-offset))
+              ((looking-at "[]})]") (- baseline rust-indent-offset))
 
               ;; Doc comments in /** style with leading * indent to line up the *s
               ((and (nth 4 (syntax-ppss)) (looking-at "*"))


### PR DESCRIPTION
This fixes #76 with the proposed solution in that issue. @muflax writes they are unsure about the wider scope of things, but the tests pass, so I thought I would suggest it, anyway.