### PR TITLE
Fix font-locking for Unicode escapes in character literals.

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1217,6 +1217,18 @@ list of substrings of `STR' each followed by its face."
      "let" font-lock-keyword-face
      "'\\\\'" font-lock-string-face)))
 
+(ert-deftest font-lock-hex-escape-character-literal ()
+  (rust-test-font-lock
+   "let ch = '\\x1f';"
+   '("let" font-lock-keyword-face
+     "'\\x1f'" font-lock-string-face)))
+
+(ert-deftest font-lock-unicode-escape-character-literal ()
+  (rust-test-font-lock
+   "let ch = '\\u{1ffff}';"
+   '("let" font-lock-keyword-face
+     "'\\u{1ffff}'" font-lock-string-face)))
+
 (ert-deftest font-lock-raw-strings-no-hashes ()
   (rust-test-font-lock
    "r\"No hashes\";"

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -83,8 +83,7 @@
       (seq
        "\\"
        (or
-        (: "U" (= 8 xdigit))
-        (: "u" (= 4 xdigit))
+        (: "u{" (** 1 6 xdigit) "}")
         (: "x" (= 2 xdigit))
         (any "'nrt0\"\\")))
       (not (any "'\\"))


### PR DESCRIPTION
* There is only \u, no \U
* \u requires braces, but allows 1-6 hex digits