### PR TITLE
Run the after-revert hook after rustfmt

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1247,6 +1247,12 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
     (rust--format-call (current-buffer))
     (goto-char cur-point)
     (set-window-start (selected-window) cur-win-start))
+
+  ;; Issue #127: Running this on a buffer acts like a revert, and could cause
+  ;; the fontification to get out of sync.  Call the same hook to ensure it is
+  ;; restored.
+  (rust--after-revert-hook)
+
   (message "Formatted buffer with rustfmt."))
 
 (defun rust-enable-format-on-save ()


### PR DESCRIPTION
Fix #127

(No tests, but there's no tests for the rest of the rustfmt feature anyway.  Such tests would either have to depend on rustfmt being installed, or fake it out in some annoying way anyway.)