### PR TITLE
Use modern properly-namespaced Common Lisp control macros (closes #130)

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -14,7 +14,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'rx)
-                   (require 'cl)
+                   (require 'cl-lib)
                    (require 'compile)
                    (require 'url-vars))
 
@@ -541,17 +541,17 @@ function or trait.  When nil, where will be aligned with fn or trait."
   "Matches names like \"foo::\" or \"Foo::\" (depending on RE-IDENT, which should match
 the desired identifiers), but does not match type annotations \"foo::<\"."
   `(lambda (limit)
-     (block nil
+     (cl-block nil
        (while t
          (let* ((symbol-then-colons (rx-to-string '(seq (group (regexp ,re-ident)) "::")))
                 (match (re-search-forward symbol-then-colons limit t)))
            (cond
             ;; If we didn't find a match, there are no more occurrences
             ;; of foo::, so return.
-            ((null match) (return nil))
+            ((null match) (cl-return nil))
             ;; If this isn't a type annotation foo::<, we've found a
             ;; match, so a return it!
-            ((not (looking-at (rx (0+ space) "<"))) (return match))))))))
+            ((not (looking-at (rx (0+ space) "<"))) (cl-return match))))))))
 
 (defvar rust-mode-font-lock-keywords
   (append


### PR DESCRIPTION
Incompatible with Emacs 24.2 and earlier, but that's several years old now.