### PR TITLE
Document how to install on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ the packages for you (under `~/.emacs.d/elpa/`).
 
 * or using <kbd>M-x package-install rust-mode</kbd>
 
+### Package installation on Debian testing or unstable
+
+```bash
+apt install elpa-rust-mode
+```
+
 ### Tests via ERT
 
 The file `rust-mode-tests.el` contains tests that can be run via


### PR DESCRIPTION
Once a new version of Debian is released (probably in mid-2017), I'll update this to document how to install rust-mode in Debian stable as well.