### PR TITLE
set derived-mode-parent for rust-mode

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2520,6 +2520,12 @@ Fontification needs to include this whole string or none of it.
     )
   )
 
+(when (fboundp 'prog-mode)
+  (ert-deftest rust-derived-mode ()
+    (with-temp-buffer
+      (rust-mode)
+      (should (derived-mode-p 'prog-mode)))))
+
 ;; If electric-pair-mode is available, load it and run the tests that use it.  If not,
 ;; no error--the tests will be skipped.
 (require 'elec-pair nil t)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1265,7 +1265,8 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (interactive)
   (setq-local rust-format-on-save nil))
 
-;; For compatibility with Emacs < 24, derive conditionally
+;; For compatibility with Emacs < 24, derive conditionally.
+;; Also see the hack after the rust-mode definition.
 (defalias 'rust-parent-mode
   (if (fboundp 'prog-mode) 'prog-mode 'fundamental-mode))
 
@@ -1318,6 +1319,11 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (setq-local electric-pair-inhibit-predicate 'rust-electric-pair-inhibit-predicate-wrap)
   (add-hook 'after-revert-hook 'rust--after-revert-hook nil t)
   (add-hook 'before-save-hook 'rust--before-save-hook nil t))
+
+;; We need this so that derived-mode-p does the right thing.
+;; This can be removed when rust-parent-mode is removed.
+(when (fboundp 'prog-mode)
+  (put 'rust-mode 'derived-mode-parent 'prog-mode))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))


### PR DESCRIPTION
When prog-mode is defined, set derived-mode-parent for rust-mode to
prog-mode.  This helps derived-mode-p work properly.  This is only
needed due to the rust-parent-mode compatibility hack; when that goes
away, this can as well.

Fixes #139.