### PR TITLE
remove emacs 23 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,10 @@ language: generic
 
 env:
   matrix:
-    - EMACS=emacs23
     - EMACS=emacs24
     - EMACS=emacs-snapshot
 
 install:
-  - if [ "$EMACS" = 'emacs23' ]; then
-       sudo apt-get -qq update &&
-       sudo apt-get -qq -f install &&
-       sudo apt-get -qq install emacs23-gtk emacs23-el;
-    fi
   - if [ "$EMACS" = 'emacs24' ]; then
        sudo add-apt-repository -y ppa:cassou/emacs &&
        sudo apt-get -qq update &&
@@ -24,14 +18,6 @@ install:
        sudo apt-get -qq -f install &&
        sudo apt-get -qq install emacs-snapshot &&
        sudo apt-get -qq install emacs-snapshot-el;
-    fi
-
-# Emacs 23 does not come with ERT.  Download it and have emacs find it
-before_script:
-  - if [ "$EMACS" = 'emacs23' ]; then
-       curl -Os https://raw.githubusercontent.com/ohler/ert/c619b56c5bc6a866e33787489545b87d79973205/lisp/emacs-lisp/ert.el &&
-       export EMACSLOADPATH=$(emacs -batch -eval "(princ (mapconcat 'identity load-path \":\"))") &&
-       export EMACSLOADPATH="$EMACSLOADPATH:$PWD";
     fi
 
 script:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 ============================================================
 
 `rust-mode` makes editing [Rust](http://rust-lang.org) code with Emacs
-enjoyable.
-
+enjoyable.  `rust-mode` requires Emacs 24 or later.
 
 ### Manual Installation
 
@@ -38,14 +37,6 @@ Then do this to load the package listing:
 * <kbd>M-x eval-buffer</kbd>
 * <kbd>M-x package-refresh-contents</kbd>
 
-If you use a version of Emacs prior to 24 that doesn't include
-`package.el`, you can get it from [here](http://git.savannah.gnu.org/gitweb/?p=emacs.git;a=blob_plain;hb=ba08b24186711eaeb3748f3d1f23e2c2d9ed0d09;f=lisp/emacs-lisp/package.el).
-
-If you have an older ELPA `package.el` installed from tromey.com, you
-should upgrade in order to support installation from multiple sources.
-The ELPA archive is deprecated and no longer accepting new packages,
-so the version there (1.7.1) is very outdated.
-
 #### Install `rust-mode`
 
 One you have `package.el`, you can install `rust-mode` or any other
@@ -72,11 +63,6 @@ The file `rust-mode-tests.el` contains tests that can be run via
 [ERT](http://www.gnu.org/software/emacs/manual/html_node/ert/index.html).
 You can use `run_rust_emacs_tests.sh` to run them in batch mode, if
 you set the environment variable EMACS to a program that runs emacs.
-
-To test it under emacs 23, which does not ship with ERT, download ert.el from
-https://raw.githubusercontent.com/ohler/ert/c619b56c5bc6a866e33787489545b87d79973205/lisp/emacs-lisp/ert.el
-and put it in a place where emacs can find it.  (ERT has shipped with emacs
-since emacs 24.)
 
 ## License
 

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2524,8 +2524,9 @@ Fontification needs to include this whole string or none of it.
 ;; no error--the tests will be skipped.
 (require 'elec-pair nil t)
 
-;; The emacs 23 version of ERT does not have test skipping functionality.  So
-;; don't even define these tests if elec-pair is not available.
+;; The emacs 23 and 24 versions of ERT do not have test skipping
+;; functionality.  So don't even define these tests if elec-pair is
+;; not available.
 (when (featurep 'elec-pair)
   (defun test-electric-pair-insert (original point-pos char closer)
     (let ((old-electric-pair-mode electric-pair-mode))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -4,6 +4,7 @@
 ;; Author: Mozilla
 ;; Url: https://github.com/rust-lang/rust-mode
 ;; Keywords: languages
+;; Package-Requires: ((emacs "24.0"))
 
 ;; This file is distributed under the terms of both the MIT license and the
 ;; Apache License (version 2.0).

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -530,11 +530,7 @@ function or trait.  When nil, where will be aligned with fn or trait."
 (defun rust-re-item-def (itype)
   (concat (rust-re-word itype) "[[:space:]]+" (rust-re-grab rust-re-ident)))
 
-;; (See PR #42 -- this is just like `(regexp-opt words 'symbols)` from
-;; newer Emacs versions, but will work on Emacs 23.)
-(defun regexp-opt-symbols (words)
-  (concat "\\_<" (regexp-opt words t) "\\_>"))
-(defconst rust-re-special-types (regexp-opt-symbols rust-special-types))
+(defconst rust-re-special-types (regexp-opt rust-special-types 'symbols))
 
 
 (defun rust-path-font-lock-matcher (re-ident)
@@ -558,10 +554,10 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
   (append
    `(
      ;; Keywords proper
-     (,(regexp-opt-symbols rust-mode-keywords) . font-lock-keyword-face)
+     (,(regexp-opt rust-mode-keywords 'symbols) . font-lock-keyword-face)
 
      ;; Special types
-     (,(regexp-opt-symbols rust-special-types) . font-lock-type-face)
+     (,(regexp-opt rust-special-types 'symbols) . font-lock-type-face)
 
      ;; The unsafe keyword
      ("\\_<unsafe\\_>" . 'rust-unsafe-face)
@@ -1266,10 +1262,6 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (interactive)
   (setq-local rust-format-on-save nil))
 
-;; For compatibility with Emacs < 24, derive conditionally
-(defalias 'rust-parent-mode
-  (if (fboundp 'prog-mode) 'prog-mode 'fundamental-mode))
-
 (defvar rust-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-f") 'rust-format-buffer)
@@ -1277,7 +1269,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   "Keymap for Rust major mode.")
 
 ;;;###autoload
-(define-derived-mode rust-mode rust-parent-mode "Rust"
+(define-derived-mode rust-mode prog-mode "Rust"
   "Major mode for Rust code.
 
 \\{rust-mode-map}"


### PR DESCRIPTION
This removes the various Emacs 23 compatibility hacks.

Fixes #137.
Fixes #139.
This also obsoletes PR #141.