### PR TITLE
Fill regular block comments correctly

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -164,6 +164,15 @@ Also, the result should be the same regardless of whether the code is at the beg
      //
      // This is the second really really really really really really long paragraph" 1 89))
 
+(ert-deftest fill-paragraph-multi-line-style-comment ()
+  (test-fill-paragraph
+   "/* This is a very very very very very very very very long string
+ */"
+   "/* This is a very very very very
+ * very very very very long
+ * string
+ */"))
+
 (ert-deftest fill-paragraph-multi-line-style-inner-doc-comment ()
   (test-fill-paragraph
    "/*! This is a very very very very very very very long string

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1058,10 +1058,10 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
   (let ((result
          ;; Replace /* with same number of spaces
          (replace-regexp-in-string
-          "\\(?:/\\*+\\)[!*]"
+          "\\(?:/\\*+\\)"
           (lambda (s)
             ;; We want the * to line up with the first * of the comment start
-            (concat (make-string (- (length s) 2) ?\x20) "*"))
+            (concat (make-string (- (length s) 1) ?\x20) "*"))
           line-start)))
     ;; Make sure we've got at least one space at the end
     (if (not (= (aref result (- (length result) 1)) ?\x20))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1058,13 +1058,18 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
   (let ((result
          ;; Replace /* with same number of spaces
          (replace-regexp-in-string
-          "\\(?:/\\*+\\)[!*]?"
+          "\\(?:/\\*+?\\)[!*]?"
           (lambda (s)
-            ;; We want the * to line up with the first * of the comment start
-            (concat (make-string (- (length s)
-                                    (if (or (string-suffix-p "!" s)
-                                            (string-suffix-p "**" s)) 2 1))
-                                 ?\x20) "*"))
+            ;; We want the * to line up with the first * of the
+            ;; comment start
+            (let ((offset (if (eq t
+                                  (compare-strings "/*" nil nil
+                                                   s
+                                                   (- (length s) 2)
+                                                   (length s)))
+                              1 2)))
+              (concat (make-string (- (length s) offset)
+                                   ?\x20) "*")))
           line-start)))
     ;; Make sure we've got at least one space at the end
     (if (not (= (aref result (- (length result) 1)) ?\x20))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1058,10 +1058,13 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
   (let ((result
          ;; Replace /* with same number of spaces
          (replace-regexp-in-string
-          "\\(?:/\\*+\\)"
+          "\\(?:/\\*+\\)[!*]?"
           (lambda (s)
             ;; We want the * to line up with the first * of the comment start
-            (concat (make-string (- (length s) 1) ?\x20) "*"))
+            (concat (make-string (- (length s)
+                                    (if (or (string-suffix-p "!" s)
+                                            (string-suffix-p "**" s)) 2 1))
+                                 ?\x20) "*"))
           line-start)))
     ;; Make sure we've got at least one space at the end
     (if (not (= (aref result (- (length result) 1)) ?\x20))


### PR DESCRIPTION
Right now fill-paragraph fills non-rustdoc block comments of the following form:

```
/* Four score and seven years ago our fathers brought forth on this continent a new nation, conceived in liberty, and dedicated to the proposition that all men are created equal. */
```

Like so: 
```
/* Four score and seven years ago our fathers brought forth on this
/* continent a new nation, conceived in liberty, and dedicated to the
/* proposition that all men are created equal. */
```

This doesn't work very well because Rust comments nest properly. This patch makes these comments format like so:

```
/* Four score and seven years ago our fathers brought forth on this
 * continent a new nation, conceived in liberty, and dedicated to the
 * proposition that all men are created equal. */
```

Which works a whole lot better. :-)