### PR TITLE
add code to handle new-style rustc errors

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1381,6 +1381,16 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   "Specifications for matching errors in rustc invocations.
 See `compilation-error-regexp-alist' for help on their format.")
 
+(defvar rustc-new-compilation-regexps
+  (let ((file "\\([^\n]+\\)")
+        (start-line "\\([0-9]+\\)")
+        (start-col  "\\([0-9]+\\)"))
+    (let ((re (concat "^ *--> " file ":" start-line ":" start-col ; --> 1:2:3
+                      )))
+      (cons re '(1 2 3))))
+  "Specifications for matching errors in rustc invocations (new style).
+See `compilation-error-regexp-alist' for help on their format.")
+
 ;; Match test run failures and panics during compilation as
 ;; compilation warnings
 (defvar cargo-compilation-regexps
@@ -1388,8 +1398,32 @@ See `compilation-error-regexp-alist' for help on their format.")
   "Specifications for matching panics in cargo test invocations.
 See `compilation-error-regexp-alist' for help on their format.")
 
+(defun rustc-scroll-down-after-next-error ()
+  "In the new style error messages, the regular expression
+   matches on the file name (which appears after `-->`), but the
+   start of the error appears a few lines earlier. This hook runs
+   after `M-x next-error`; it simply scrolls down a few lines in
+   the compilation window until the top of the error is visible."
+  (save-selected-window
+    (when (eq major-mode 'rust-mode)
+      (select-window (get-buffer-window next-error-last-buffer))
+      (when (save-excursion
+              (beginning-of-line)
+              (looking-at " *-->"))
+        (let ((start-of-error
+               (save-excursion
+                 (beginning-of-line)
+                 (while (not (looking-at "^[a-z]+:"))
+                   (forward-line -1))
+                 (point))))
+          (set-window-start (selected-window) start-of-error))))))
+
 (eval-after-load 'compile
   '(progn
+     (add-to-list 'compilation-error-regexp-alist-alist
+                  (cons 'rustc-new rustc-new-compilation-regexps))
+     (add-to-list 'compilation-error-regexp-alist 'rustc-new)
+     (add-hook 'next-error-hook 'rustc-scroll-down-after-next-error)
      (add-to-list 'compilation-error-regexp-alist-alist
                   (cons 'rustc rustc-compilation-regexps))
      (add-to-list 'compilation-error-regexp-alist 'rustc)


### PR DESCRIPTION
These errors are available on nightly builds (or will be soon), but only (at the moment) when enabled via environment variable. They will become the default at some point in the future. In this commit we match on the `-->`, but after that we have to scroll the compilation window to make the error visible. 

(One shortcoming of this commit is that the resulting colors could be better: emacs highlights the filename and line-number, but not the error message itself. I consider the result suboptimal. I considered adding more logic here to add a "bold" attribute to the error message lines, but haven't had time to try it out.)

r? @MicahChalmer 