### PR TITLE
Improve imenu support

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1195,16 +1195,15 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
 ;;; Imenu support
 (defvar rust-imenu-generic-expression
   (append (mapcar #'(lambda (x)
-                      (list nil (rust-re-item-def-imenu x) 1))
-                  '("enum" "struct" "type" "mod" "fn" "trait" "macro_rules!"))
-          `(("Impl" ,(rust-re-item-def-imenu "impl") 1)))
+                      (list (capitalize x) (rust-re-item-def-imenu x) 1))
+                  '("enum" "struct" "type" "mod" "fn" "trait" "impl"))
+          `(("Macro" ,(rust-re-item-def-imenu "macro_rules!") 1)))
   "Value for `imenu-generic-expression' in Rust mode.
 
-Create a flat index of the item definitions in a Rust file.
+Create a hierarchical index of the item definitions in a Rust file.
 
-Imenu will show all the enums, structs, etc. at the same level.
-Implementations will be shown under the `Impl` subheading.  Use
-idomenu (imenu with `ido-mode') for best mileage.")
+Imenu will show all the enums, structs, etc. in their own subheading.
+Use idomenu (imenu with `ido-mode') for best mileage.")
 
 ;;; Defun Motions
 

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1196,7 +1196,7 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
 (defvar rust-imenu-generic-expression
   (append (mapcar #'(lambda (x)
                       (list nil (rust-re-item-def-imenu x) 1))
-                  '("enum" "struct" "type" "mod" "fn" "trait"))
+                  '("enum" "struct" "type" "mod" "fn" "trait" "macro_rules!"))
           `(("Impl" ,(rust-re-item-def-imenu "impl") 1)))
   "Value for `imenu-generic-expression' in Rust mode.
 
@@ -1340,6 +1340,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (setq-local comment-multi-line t)
   (setq-local comment-line-break-function 'rust-comment-indent-new-line)
   (setq-local imenu-generic-expression rust-imenu-generic-expression)
+  (setq-local imenu-syntax-alist '((?! . "w"))) ; For macro_rules!
   (setq-local beginning-of-defun-function 'rust-beginning-of-defun)
   (setq-local end-of-defun-function 'rust-end-of-defun)
   (setq-local parse-sexp-lookup-properties t)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -31,6 +31,7 @@
 (defconst rust-re-ident "[[:word:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*")
 (defconst rust-re-lc-ident "[[:lower:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*")
 (defconst rust-re-uc-ident "[[:upper:]][[:word:][:multibyte:]_[:digit:]]*")
+(defconst rust-re-vis "pub")
 
 (defconst rust-re-non-standard-string
   (rx
@@ -543,8 +544,13 @@ buffer."
 (defconst rust-re-pre-expression-operators "[-=!%&*/:<>[{(|.^;}]")
 (defun rust-re-word (inner) (concat "\\<" inner "\\>"))
 (defun rust-re-grab (inner) (concat "\\(" inner "\\)"))
+(defun rust-re-shy (inner) (concat "\\(?:" inner "\\)"))
 (defun rust-re-item-def (itype)
   (concat (rust-re-word itype) "[[:space:]]+" (rust-re-grab rust-re-ident)))
+(defun rust-re-item-def-imenu (itype)
+  (concat "^[[:space:]]*"
+          (rust-re-shy (concat (rust-re-word rust-re-vis) "[[:space:]]+")) "?"
+          (rust-re-item-def itype)))
 
 (defconst rust-re-special-types (regexp-opt rust-special-types 'symbols))
 
@@ -1189,9 +1195,9 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
 ;;; Imenu support
 (defvar rust-imenu-generic-expression
   (append (mapcar #'(lambda (x)
-                      (list nil (rust-re-item-def x) 1))
+                      (list nil (rust-re-item-def-imenu x) 1))
                   '("enum" "struct" "type" "mod" "fn" "trait"))
-          `(("Impl" ,(rust-re-item-def "impl") 1)))
+          `(("Impl" ,(rust-re-item-def-imenu "impl") 1)))
   "Value for `imenu-generic-expression' in Rust mode.
 
 Create a flat index of the item definitions in a Rust file.


### PR DESCRIPTION
This PR does three things to the imenu support of rust-mode:

- Fix #94 (avoid picking up items in single-line comments)
- Fix #93 (all items show up as top-level in imenu)
- Adds macro_rules names to imenu

#### Fix #94
#94 is definitely a bug.  Imenu picked up item definitions in single-line comments, but not multi-line comments apparently.

I've added a regexp derived from `rust-re-item-def` that strictly matches from the beginning of the line to avoid.  Since items can have a `pub` keyword for visibility in front of them, I match that optionally.

I did not modify `rust-re-item-def` since it was used for font-locking as well as imenu.  Though it should work there as well.

#### Fix #93
#93 seemed like a deliberate choice, since the comment for the `rust-imenu-generic-expression` is coherent with the code.

I think it's more useful to have separate categories, since I can immediately distinguish between an `impl` and a `struct` of the same name.  But I only use imenu through Helm, so it might have downsides for other use cases.

You can cherry-pick, or I can update the PR if you'd rather have every definition (except impls) at the top-level.

#### Add macro_rules
I love macros!  rust-mode did not add them to imenu previously.  But I find it very useful to jump to them in large files.

This is just a matter of adding `macro_rules!` to the items we map over in defining `rust-imenu-generic-expression`.  But this doesn't work yet.  I suppose this is because of the `!`, which is not picked up by the regexp that uses word boundaries.  Adding `!` to the imenu syntax table let us reuse the regexp.

#### Correctness
I've tested the PR to work locally.  It doesn't break any ERT test (though there may not be any imenu-specific tests).

My understanding of all that stuff is quite superficial, so there might be downsides to the way I've approached it.  I can update the PR as needed per review.