### PR TITLE
[master] Copy buffer only when format changes.

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1258,8 +1258,10 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
     (erase-buffer)
     (insert-buffer-substring buf)
     (if (zerop (call-process-region (point-min) (point-max) rust-rustfmt-bin t t nil))
-        (progn (copy-to-buffer buf (point-min) (point-max))
-               (kill-buffer))
+        (progn
+          (if (not (string= (buffer-string) (with-current-buffer buf (buffer-string))))
+              (progn (copy-to-buffer buf (point-min) (point-max))))
+          (kill-buffer))
       (error "Rustfmt failed, see *rustfmt* buffer for details"))))
 
 (defun rust-format-buffer ()

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1260,7 +1260,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
     (if (zerop (call-process-region (point-min) (point-max) rust-rustfmt-bin t t nil))
         (progn
           (if (not (string= (buffer-string) (with-current-buffer buf (buffer-string))))
-              (progn (copy-to-buffer buf (point-min) (point-max))))
+              (copy-to-buffer buf (point-min) (point-max)))
           (kill-buffer))
       (error "Rustfmt failed, see *rustfmt* buffer for details"))))
 


### PR DESCRIPTION
In formatting code, only copies when `rustfmt` actually changed something. This will save some meaningless "changed buffer" signs even if there is no change.