### PR TITLE
Correctly restore point position after running rustfmt

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2561,6 +2561,18 @@ Fontification needs to include this whole string or none of it.
     )
   )
 
+(ert-deftest rust-test-revert-hook-preserves-point ()
+  (with-temp-buffer
+    ;; Insert some code, and put point in the middle.
+    (insert "fn foo() {}\n")
+    (insert "fn bar() {}\n")
+    (insert "fn baz() {}\n")
+    (goto-char (point-min))
+    (forward-line 1)
+    (let ((initial-point (point)))
+      (rust--after-revert-hook)
+      (should (equal initial-point (point))))))
+
 ;; If electric-pair-mode is available, load it and run the tests that use it.  If not,
 ;; no error--the tests will be skipped.
 (require 'elec-pair nil t)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1365,9 +1365,10 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   ;; to use `font-lock-ensure', which doesn't exist in Emacs 24 and earlier.
   ;; If it's not available, fall back to calling `font-lock-fontify-region'
   ;; on the whole buffer.
-  (if (fboundp 'font-lock-ensure)
-      (font-lock-ensure)
-    (font-lock-fontify-region (point-min) (point-max))))
+  (save-excursion
+    (if (fboundp 'font-lock-ensure)
+        (font-lock-ensure)
+      (font-lock-fontify-region (point-min) (point-max)))))
 
 (defun rust--before-save-hook ()
   (when rust-format-on-save (rust-format-buffer)))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1270,10 +1270,16 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (unless (executable-find rust-rustfmt-bin)
     (error "Could not locate executable \"%s\"" rust-rustfmt-bin))
 
-  (let ((cur-point (point))
+  (let ((cur-line (line-number-at-pos))
+        (cur-column (current-column))
         (cur-win-start (window-start)))
     (rust--format-call (current-buffer))
-    (goto-char cur-point)
+    ;; Move to the same line and column as before.  This is best
+    ;; effort: if rustfmt inserted lines before point, we end up in
+    ;; the wrong place. See issue #162.
+    (goto-char (point-min))
+    (forward-line (1- cur-line))
+    (forward-char cur-column)
     (set-window-start (selected-window) cur-win-start))
 
   ;; Issue #127: Running this on a buffer acts like a revert, and could cause


### PR DESCRIPTION
The previous approach simply moved to the same character offset. This is
unlikely to preserve the position of point, as rustfmt often changes
whitespace, changing the number of characters before point.

Instead, we go back to the line number and column number we were on
before. Provided that rustfmt has not radically changed the number of
lines, this will typically put point back to its previous position, or
at least close.

Improves, but doesn't completely solve, issue #162.