### PR TITLE
fix regex to account for `[E123]`

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1413,7 +1413,7 @@ See `compilation-error-regexp-alist' for help on their format.")
         (let ((start-of-error
                (save-excursion
                  (beginning-of-line)
-                 (while (not (looking-at "^[a-z]+:"))
+                 (while (not (looking-at "^[a-z]+:\\|^[a-z]+\\[E[0-9]+\\]:"))
                    (forward-line -1))
                  (point))))
           (set-window-start (selected-window) start-of-error))))))


### PR DESCRIPTION
The old regex was fine when it was written, but the style changed since then.