### PR TITLE
Fix #168: use while in rust-rewind-irrelevant

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1162,6 +1162,23 @@ All positions are position symbols found in `rust-test-positions-alist'."
    'nonblank-line-indented-already-middle-target
    #'indent-for-tab-command))
 
+(ert-deftest no-stack-overflow-in-rust-rewind-irrelevant ()
+  (with-temp-buffer
+    (rust-mode)
+    (insert "fn main() {\n    let x = 1;")
+    ;; Insert 150 separate comments on the same line
+    (dotimes (i 150)
+      (insert "/* foo */ "))
+    ;; Rewinding from the last commment to the end of the let needs at least
+    ;; 150 iterations, but if we limit the stack depth to 100 (this appears to
+    ;; be some minimum), a recursive function would overflow, throwing an
+    ;; error.
+    (let ((max-lisp-eval-depth 100))
+      (rust-rewind-irrelevant)
+      ;; Only a non-stack overflowing function would make it this far.  Also
+      ;; check that we rewound till after the ;
+      (should (= (char-before) ?\;)))))
+
 (defun rust-test-fontify-string (str)
   (with-temp-buffer
     (rust-mode)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -201,14 +201,20 @@ function or trait.  When nil, where will be aligned with fn or trait."
 (defun rust-paren-level () (nth 0 (syntax-ppss)))
 (defun rust-in-str-or-cmnt () (nth 8 (syntax-ppss)))
 (defun rust-rewind-past-str-cmnt () (goto-char (nth 8 (syntax-ppss))))
+
 (defun rust-rewind-irrelevant ()
-  (let ((starting (point)))
-    (skip-chars-backward "[:space:]\n")
-    (if (rust-looking-back-str "*/") (backward-char))
-    (if (rust-in-str-or-cmnt)
-        (rust-rewind-past-str-cmnt))
-    (if (/= starting (point))
-        (rust-rewind-irrelevant))))
+  (let ((continue t))
+    (while continue
+      (let ((starting (point)))
+        (skip-chars-backward "[:space:]\n")
+        (when (rust-looking-back-str "*/")
+          (backward-char))
+        (when (rust-in-str-or-cmnt)
+          (rust-rewind-past-str-cmnt))
+        ;; Rewind until the point no longer moves
+        (setq continue (/= starting (point)))))))
+
+
 (defun rust-in-macro ()
   (save-excursion
     (when (> (rust-paren-level) 0)


### PR DESCRIPTION
Rewrite the recursive function `rust-rewind-irrelevant`, which causes a
stack overflow in #168, using a `while` loop.