### PR TITLE
Handle comments when indenting method chains

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1599,6 +1599,19 @@ fn main() {
 "
    )))
 
+(ert-deftest indent-method-chains-look-over-comment ()
+  (let ((rust-indent-method-chain t)) (test-indent
+   "
+fn main() {
+    thing.a.do_it
+    // A comment
+           .aligned
+    // Another comment
+           .more_alignment();
+}
+"
+   )))
+
 (ert-deftest indent-method-chains-comment ()
   (let ((rust-indent-method-chain t)) (test-indent
    "
@@ -1626,6 +1639,17 @@ fn main() { // comment here should not push next line out
 }
 "
    )))
+
+(ert-deftest indent-method-chains-after-comment2 ()
+  (let ((rust-indent-method-chain t)) (test-indent
+   "
+fn main() {
+    // Lorem ipsum lorem ipsum lorem ipsum lorem.ipsum
+    foo.bar()
+}
+"
+   )))
+
 
 (ert-deftest test-for-issue-36-syntax-corrupted-state ()
   "This is a test for a issue #36, which involved emacs's

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -301,6 +301,17 @@ buffer."
     (when (looking-at (concat "\s*\." rust-re-ident))
       (forward-line -1)
       (end-of-line)
+      ;; Keep going up (looking for a line that could contain a method chain)
+      ;; while we're in a comment or on a blank line. Stop when the paren
+      ;; level changes.
+      (let ((level (rust-paren-level)))
+        (while (and (or (rust-in-str-or-cmnt)
+                        ;; Only whitespace (or nothing) from the beginning to
+                        ;; the end of the line.
+                        (looking-back "^\s*" (point-at-bol)))
+                    (= (rust-paren-level) level))
+          (forward-line -1)
+          (end-of-line)))
 
       (let
           ;; skip-dot-identifier is used to position the point at the


### PR DESCRIPTION
Previously, indentation went wrong when the comment on the line above looked like a method call/member access:

```rust
fn main() {
    // Lorem ipsum lorem ipsum lorem ipsum lorem.ipsum
                                            foo.bar()
}
```

With this patch:

```rust
fn main() {
    // Lorem ipsum lorem ipsum lorem ipsum lorem.ipsum
    foo.bar()
}
```

Also, a blank line or a comment broke method-chain indentation:

```rust
fn main() {
    something.a.do_it
    // A comment
        .aligned

        .more_alignment();
}
```

With this patch:

```rust
fn main() {
    something.a.do_it
    // A comment
               .aligned

               .more_alignment();
}
```

Note that comments interleaving a method chain are not aligned with the '.' of the method chain.