### PR TITLE
Bump version

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1,6 +1,6 @@
 ;;; rust-mode.el --- A major emacs mode for editing Rust source code -*-lexical-binding: t-*-
 
-;; Version: 0.2.0
+;; Version: 0.3.0
 ;; Author: Mozilla
 ;; Url: https://github.com/rust-lang/rust-mode
 ;; Keywords: languages


### PR DESCRIPTION
Sorry if this is too forward, but it was suggested in #87 that someone who wants a (new) version to be released/tagged should just open a pull request, so that's what I'm doing. My hope is that you will create a git tag for this version so that it shows up in Melpa Stable, or at the very least get the release discussion going again. If you don't, then this pull request really has no meaning.

I thought I'd stay conservative with the new version number, as I just wanted to try some rust in Emacs today and found that rust-mode wasn't available on melpa stable and don't actually know anything about this project yet (in terms of goals, open issues, etc.). If this project is already in a state where you feel that all the initial goals of the project have been reached and no backward-incompatible changes will happen in the forseable future, then the version could of course be changed to 1.0.0 instead. All of this is assuming that you (will want to) adhere to semantic versioning, if you don't then any version number will do.

Creating a release isn't just about users wanting to install rust-mode while using melpa stable, but also about at least 2 packages (racer and cargo) which are in melpa stable, but can't be installed due to depending on an unavailable package (rust-mode).

In case you care about completeness, commits 4c1eab5 and 5afc8ab may also be prime candidates for tagging as they changed the versions to 0.2.0 and 0.1.0 respectively.

So whatever you do, _please_ tag a release.
