### PR TITLE
fix rust indentation bug

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1628,6 +1628,34 @@ fn main() {
 "
    )))
 
+(ert-deftest indent-function-after-where ()
+  (let ((rust-indent-method-chain t)) (test-indent
+   "
+fn each_split_within<'a, F>(ss: &'a str, lim: usize, mut it: F)
+                            -> bool where F: FnMut(&'a str) -> bool {
+}
+
+#[test]
+fn test_split_within() {
+}
+"
+   )))
+
+(ert-deftest indent-function-after-where-nested ()
+  (let ((rust-indent-method-chain t)) (test-indent
+   "
+fn outer() {
+    fn each_split_within<'a, F>(ss: &'a str, lim: usize, mut it: F)
+                                -> bool where F: FnMut(&'a str) -> bool {
+    }
+    #[test]
+    fn test_split_within() {
+    }
+    fn bar() {
+    }
+}
+"
+   )))
 
 (ert-deftest test-for-issue-36-syntax-corrupted-state ()
   "This is a test for a issue #36, which involved emacs's


### PR DESCRIPTION
This patch fixes a bug I found where rust-mode would misindent code
like:

fn each_split_within<'a, F>(ss: &'a str, lim: usize, mut it: F)
                            -> bool where F: FnMut(&'a str) -> bool {
}

fn test_split_within() {
}

In particular the second "fn" would be indented a level.

On the "fn" line, rust-mode-indent-line was calling
rust-beginning-of-defun, which would go to the previous defun.  Fixing
this required moving the definition of rust-top-item-beg-re higher in
the file, before its first use (recent versions of Emacs insist on
this).  And, this required removing the "^" from this regexp, which is
ok because the sole use is already adding a "^".

This patch includes the above as a new test case.