### PR TITLE
set open-paren-in-column-0-is-defun-start to nil

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1876,6 +1876,21 @@ pub fn foo<T,
     hello();
 }"))
 
+(ert-deftest indent-open-paren-in-column0 ()
+  ;; Just pass the same text for the "deindented" argument.  This
+  ;; avoids the extra spaces normally inserted, which would mess up
+  ;; the test because string contents aren't touched by reindentation.
+  (let ((text "
+const a: &'static str = r#\"
+{}\"#;
+fn main() {
+    let b = \"//\";
+    let c = \"\";
+
+}
+"))
+    (test-indent text text)))
+
 (defun rust-test-matching-parens (content pairs &optional nonparen-positions)
   "Assert that in rust-mode, given a buffer with the given `content',
   emacs's paren matching will find all of the pairs of positions

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1456,6 +1456,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (setq-local comment-start "// ")
   (setq-local comment-end   "")
   (setq-local indent-tabs-mode nil)
+  (setq-local open-paren-in-column-0-is-defun-start nil)
 
   ;; Auto indent on }
   (setq-local


### PR DESCRIPTION
Set open-paren-in-column-0-is-defun-start to nil in rust-mode.  This
setting is a performance hack in Emacs, at the expense of correctness in
some cases.  However, due to the syntax-ppss cache, I doubt whether this
hack is needed for Rust code.

Fixes #107