### PR TITLE
fix syntax of "<" appearing after "?"

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1891,6 +1891,13 @@ fn main() {
 "))
     (test-indent text text)))
 
+(ert-deftest indent-question-mark-operator ()
+  (test-indent "fn foo() {
+    if bar()? < 1 {
+    }
+    baz();
+}"))
+
 (defun rust-test-matching-parens (content pairs &optional nonparen-positions)
   "Assert that in rust-mode, given a buffer with the given `content',
   emacs's paren matching will find all of the pairs of positions

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1012,6 +1012,9 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
        ((rust-looking-back-symbols rust-mode-keywords)
         (rust-looking-back-symbols '("self" "true" "false")))
 
+       ((rust-looking-back-str "?")
+	(rust-is-in-expression-context 'ambiguous-operator))
+
        ;; If we're looking back at an identifier, this depends on whether
        ;; the identifier is part of an expression or a type
        ((rust-looking-back-ident)


### PR DESCRIPTION
The "<" syntax-setting code could be confused after a "?".  This patch
changes the code to treat "?" as an "ambiguous operator" and adjust
according to further context.
Fixes #200