### PR TITLE
Allow formatting with long lines (fixes #186)

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1195,24 +1195,26 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (with-current-buffer (get-buffer-create "*rustfmt*")
     (erase-buffer)
     (insert-buffer-substring buf)
-    (let ((tmpf (make-temp-file "rustfmt")))
-      (let ((ret (call-process-region (point-min) (point-max) rust-rustfmt-bin
-                                      t `(t ,tmpf) nil)))
-        (cond
-         ((zerop ret)
-          (if (not (string= (buffer-string)
-                            (with-current-buffer buf (buffer-string))))
-              (copy-to-buffer buf (point-min) (point-max)))
-          (kill-buffer))
-         ((= ret 3)
-          (if (not (string= (buffer-string)
-                            (with-current-buffer buf (buffer-string))))
-              (copy-to-buffer buf (point-min) (point-max)))
-          (erase-buffer)
-          (insert-file-contents tmpf)
-          (error "Rustfmt could not format some lines, see *rustfmt* buffer for details"))
-         (t
-          (error "Rustfmt failed, see *rustfmt* buffer for details")))))))
+    (let* ((tmpf (make-temp-file "rustfmt"))
+           (ret (call-process-region (point-min) (point-max) rust-rustfmt-bin
+                                     t `(t ,tmpf) nil)))
+      (unwind-protect
+          (cond
+           ((zerop ret)
+            (if (not (string= (buffer-string)
+                              (with-current-buffer buf (buffer-string))))
+                (copy-to-buffer buf (point-min) (point-max)))
+            (kill-buffer))
+           ((= ret 3)
+            (if (not (string= (buffer-string)
+                              (with-current-buffer buf (buffer-string))))
+                (copy-to-buffer buf (point-min) (point-max)))
+            (erase-buffer)
+            (insert-file-contents tmpf)
+            (error "Rustfmt could not format some lines, see *rustfmt* buffer for details"))
+           (t
+            (error "Rustfmt failed, see *rustfmt* buffer for details"))))
+      (delete-file tmpf))))
 
 (defconst rust--format-word "\\b\\(else\\|enum\\|fn\\|for\\|if\\|let\\|loop\\|match\\|struct\\|unsafe\\|while\\)\\b")
 (defconst rust--format-line "\\([\n]\\)")

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1198,7 +1198,6 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
     (let ((tmpf (make-temp-file "rustfmt")))
       (let ((ret (call-process-region (point-min) (point-max) rust-rustfmt-bin
                                       t `(t ,tmpf) nil)))
-        (format-message "%d" ret)
         (cond
          ((zerop ret)
           (error "Rustfmt failed, see *rustfmt* buffer for details"))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1195,12 +1195,13 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (with-current-buffer (get-buffer-create "*rustfmt*")
     (erase-buffer)
     (insert-buffer-substring buf)
-    (if (zerop (call-process-region (point-min) (point-max) rust-rustfmt-bin t t nil))
-        (progn
-          (if (not (string= (buffer-string) (with-current-buffer buf (buffer-string))))
-              (copy-to-buffer buf (point-min) (point-max)))
-          (kill-buffer))
-      (error "Rustfmt failed, see *rustfmt* buffer for details"))))
+    (let ((ret (call-process-region (point-min) (point-max) rust-rustfmt-bin t '(t nil) nil)))
+      (if (or (zerop ret) (= ret 3))
+          (progn
+            (if (not (string= (buffer-string) (with-current-buffer buf (buffer-string))))
+                (copy-to-buffer buf (point-min) (point-max)))
+            (kill-buffer))
+        (error "Rustfmt failed, see *rustfmt* buffer for details")))))
 
 (defconst rust--format-word "\\b\\(else\\|enum\\|fn\\|for\\|if\\|let\\|loop\\|match\\|struct\\|unsafe\\|while\\)\\b")
 (defconst rust--format-line "\\([\n]\\)")

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1200,7 +1200,10 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
                                       t `(t ,tmpf) nil)))
         (cond
          ((zerop ret)
-          (error "Rustfmt failed, see *rustfmt* buffer for details"))
+          (if (not (string= (buffer-string)
+                            (with-current-buffer buf (buffer-string))))
+              (copy-to-buffer buf (point-min) (point-max)))
+          (kill-buffer))
          ((= ret 3)
           (if (not (string= (buffer-string)
                             (with-current-buffer buf (buffer-string))))
@@ -1209,10 +1212,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
           (insert-file-contents tmpf)
           (error "Rustfmt could not format some lines, see *rustfmt* buffer for details"))
          (t
-          (if (not (string= (buffer-string)
-                            (with-current-buffer buf (buffer-string))))
-              (copy-to-buffer buf (point-min) (point-max)))
-          (kill-buffer)))))))
+          (error "Rustfmt failed, see *rustfmt* buffer for details")))))))
 
 (defconst rust--format-word "\\b\\(else\\|enum\\|fn\\|for\\|if\\|let\\|loop\\|match\\|struct\\|unsafe\\|while\\)\\b")
 (defconst rust--format-line "\\([\n]\\)")


### PR DESCRIPTION
It's very annoying to not be able to format files with long comments. This provides a solution to that; but the stderr output is not displayed anywhere. I think that should be added at some point, but it's not really necessary to at least allow formatting these files. The stderr output will let you know which lines exceed the line length, which you might care about if you want to be strict about enforcing line length.