### PR TITLE
restore points even when an error occurs

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1326,19 +1326,20 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
                         (rust--format-get-loc buffer start)
                         (rust--format-get-loc buffer point))
                   window-loc)))))
-    (rust--format-call (current-buffer))
-    (dolist (loc buffer-loc)
-      (let* ((buffer (pop loc))
-             (pos (rust--format-get-pos buffer (pop loc))))
-        (with-current-buffer buffer
-          (goto-char pos))))
-    (dolist (loc window-loc)
-      (let* ((window (pop loc))
-             (buffer (window-buffer window))
-             (start (rust--format-get-pos buffer (pop loc)))
-             (pos (rust--format-get-pos buffer (pop loc))))
-        (set-window-start window start)
-        (set-window-point window pos))))
+    (unwind-protect
+        (rust--format-call (current-buffer))
+      (dolist (loc buffer-loc)
+        (let* ((buffer (pop loc))
+               (pos (rust--format-get-pos buffer (pop loc))))
+          (with-current-buffer buffer
+            (goto-char pos))))
+      (dolist (loc window-loc)
+        (let* ((window (pop loc))
+               (buffer (window-buffer window))
+               (start (rust--format-get-pos buffer (pop loc)))
+               (pos (rust--format-get-pos buffer (pop loc))))
+          (set-window-start window start)
+          (set-window-point window pos)))))
 
   (message "Formatted buffer with rustfmt."))
 


### PR DESCRIPTION
`rust--format-call` may change buffer then exit with errors especially when rustfmt exits with status 3. When it happens the cursor gets at the beginning of buffer, which is very annoying.