### PR TITLE
Highlight question mark operator using new `rust-question-mark-face'

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1510,6 +1510,38 @@ this_is_not_a_string();)"
    ;; Only the i32 should have been highlighted.
    '("i32" font-lock-type-face)))
 
+(ert-deftest font-lock-question-mark ()
+  "Ensure question mark operator is highlighted."
+  (rust-test-font-lock
+   "?"
+   '("?" rust-question-mark-face))
+  (rust-test-font-lock
+   "foo\(\)?;"
+   '("?" rust-question-mark-face))
+  (rust-test-font-lock
+   "foo\(bar\(\)?\);"
+   '("?" rust-question-mark-face))
+  (rust-test-font-lock
+   "\"?\""
+   '("\"?\"" font-lock-string-face))
+  (rust-test-font-lock
+   "foo\(\"?\"\);"
+   '("\"?\"" font-lock-string-face))
+  (rust-test-font-lock
+   "// ?"
+   '("// " font-lock-comment-delimiter-face
+     "?" font-lock-comment-face))
+  (rust-test-font-lock
+   "/// ?"
+   '("/// ?" font-lock-doc-face))
+  (rust-test-font-lock
+   "foo\(\"?\"\);"
+   '("\"?\"" font-lock-string-face))
+  (rust-test-font-lock
+   "foo\(\"?\"\)?;"
+   '("\"?\"" font-lock-string-face
+     "?" rust-question-mark-face)))
+
 (ert-deftest rust-test-default-context-sensitive ()
   (rust-test-font-lock
    "let default = 7; impl foo { default fn f() { } }"

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -165,6 +165,11 @@ function or trait.  When nil, where will be aligned with fn or trait."
   "Face for the `unsafe' keyword."
   :group 'rust-mode)
 
+(defface rust-question-mark-face
+  '((t :weight bold :inherit font-lock-builtin-face))
+  "Face for the question mark operator."
+  :group 'rust-mode)
+
 (defun rust-paren-level () (nth 0 (syntax-ppss)))
 (defun rust-in-str-or-cmnt () (nth 8 (syntax-ppss)))
 (defun rust-rewind-past-str-cmnt () (goto-char (nth 8 (syntax-ppss))))
@@ -603,6 +608,9 @@ the desired identifiers), but does not match type annotations \"foo::<\"."
 
      ;; CamelCase Means Type Or Constructor
      (,rust-re-type-or-constructor 1 font-lock-type-face)
+
+     ;; Question mark operator
+     ("\\?" . 'rust-question-mark-face)
      )
 
    ;; Item definitions


### PR DESCRIPTION
This is a pretty small change even with basic tests. I’ve only given the face bold styling and let it inherit from `font-lock-builtin-face`, to avoid making it jarring, but of course users can customize the face.

Related: #171.