### PR TITLE
Fix recognition of "<" as operator in some context

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2034,6 +2034,17 @@ fn main() {
     baz();
 }"))
 
+;; Regression test for #212.
+(ert-deftest indent-left-shift ()
+  (test-indent "
+fn main() {
+    let a = [[0u32, 0u32]; 1];
+    let i = 0;
+    let x = a[i][(1 < i)];
+    let x = a[i][(1 << i)];
+}
+"))
+
 (defun rust-test-matching-parens (content pairs &optional nonparen-positions)
   "Assert that in rust-mode, given a buffer with the given `content',
   emacs's paren matching will find all of the pairs of positions

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -812,6 +812,9 @@ match data if found. Returns nil if not within a Rust string."
        ;; it to be an expression.
        ((and (equal token 'open-brace) (rust-looking-back-macro)) t)
        
+       ;; In a brace context a "]" introduces an expression.
+       ((and (eq token 'open-brace) (rust-looking-back-str "]")))
+
        ;; An identifier is right after an ending paren, bracket, angle bracket
        ;; or curly brace.  It's a type if the last sexp was a type.
        ((and (equal token 'ident) (equal 5 (rust-syntax-class-before-point)))


### PR DESCRIPTION
rust-mode identifies the "<<" as open angle brackets in
    let x = a[i][(1 << i)];
This patch fixes the problem by changing rust-is-in-expression-context
to treat "]" as starting an expression in brace context.

Fixes #212