### PR TITLE
Types get correct font-lock in if-let statements

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2345,6 +2345,15 @@ fn main() {
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face)))
 
+(ert-deftest rust-if-let-type-font-lock ()
+  (rust-test-font-lock
+   "if let Some(var) = some_var { /* no-op */ }"
+   '("if" font-lock-keyword-face
+     "let" font-lock-keyword-face
+     "Some" font-lock-type-face
+     "/* " font-lock-comment-delimiter-face
+     "no-op */" font-lock-comment-face)))
+
 (ert-deftest rust-test-basic-paren-matching ()
   (rust-test-matching-parens
    "

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1317,6 +1317,15 @@ list of substrings of `STR' each followed by its face."
      "mut" font-lock-keyword-face
      "bar" font-lock-variable-name-face)))
 
+(ert-deftest font-lock-if-let-binding ()
+  (rust-test-font-lock
+   "if let Some(var) = some_var { /* no-op */ }"
+   '("if" font-lock-keyword-face
+     "let" font-lock-keyword-face
+     "Some" font-lock-type-face
+     "/* " font-lock-comment-delimiter-face
+     "no-op */" font-lock-comment-face)))
+
 (ert-deftest font-lock-single-quote-character-literal ()
   (rust-test-font-lock
    "fn main() { let ch = '\\''; }"
@@ -2342,15 +2351,6 @@ fn main() {
      "}} efgh " font-lock-string-face
      "{1}" rust-string-interpolation-face
      "\"" font-lock-string-face
-     "/* " font-lock-comment-delimiter-face
-     "no-op */" font-lock-comment-face)))
-
-(ert-deftest rust-if-let-type-font-lock ()
-  (rust-test-font-lock
-   "if let Some(var) = some_var { /* no-op */ }"
-   '("if" font-lock-keyword-face
-     "let" font-lock-keyword-face
-     "Some" font-lock-type-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face)))
 

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -682,6 +682,9 @@ match data if found. Returns nil if not within a Rust string."
      ;; Field names like `foo:`, highlight excluding the :
      (,(concat (rust-re-grab rust-re-ident) ":[^:]") 1 font-lock-variable-name-face)
 
+     ;; CamelCase Means Type Or Constructor
+     (,rust-re-type-or-constructor 1 font-lock-type-face)
+
      ;; Type-inferred binding
      (,(concat "\\_<\\(?:let\\|ref\\)\\s-+\\(?:mut\\s-+\\)?" (rust-re-grab rust-re-ident) "\\_>") 1 font-lock-variable-name-face)
 
@@ -693,9 +696,6 @@ match data if found. Returns nil if not within a Rust string."
 
      ;; Lifetimes like `'foo`
      (,(concat "'" (rust-re-grab rust-re-ident) "[^']") 1 font-lock-variable-name-face)
-
-     ;; CamelCase Means Type Or Constructor
-     (,rust-re-type-or-constructor 1 font-lock-type-face)
 
      ;; Question mark operator
      ("\\?" . 'rust-question-mark-face)


### PR DESCRIPTION
Changed so that font-locking for types is considered before font-locking for variable names in let bindings.
Fixes #232 