### PR TITLE
Pass 'visible to get-buffer-window

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1609,7 +1609,7 @@ See `compilation-error-regexp-alist' for help on their format.")
    the compilation window until the top of the error is visible."
   (save-selected-window
     (when (eq major-mode 'rust-mode)
-      (select-window (get-buffer-window next-error-last-buffer))
+      (select-window (get-buffer-window next-error-last-buffer 'visible))
       (when (save-excursion
               (beginning-of-line)
               (looking-at " *-->"))


### PR DESCRIPTION
If I have two frames, with the *compilation* buffer in one frame and
use next-error in the other frame, I get this error:

Wrong type argument: window-live-p, nil

This happens because get-buffer-window returns nil.  The fix is to
pass 'visible to get-buffer-window, which will pick any visible frame
from the same terminal.