### PR TITLE
Improved font-locking for print macros

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2186,6 +2186,19 @@ fn main() {
      "\"\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "print!(\"\"); */" font-lock-comment-face))
+  ;; with newline directly following delimiter
+  (rust-test-font-lock
+   "print!(\n\"\"\n); { /* print!(\"\"); */ }"
+   '("print!" rust-builtin-formatting-macro-face
+     "\"\"" font-lock-string-face
+     "/* " font-lock-comment-delimiter-face
+     "print!(\"\"); */" font-lock-comment-face))
+  ;; with empty println!()
+  (rust-test-font-lock
+   "println!(); { /* println!(); */ }"
+   '("println!" rust-builtin-formatting-macro-face
+     "/* " font-lock-comment-delimiter-face
+     "println!(); */" font-lock-comment-face))
   ;; other delimiters
   (rust-test-font-lock
    "print!{\"\"}; { /* no-op */ }"

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -633,7 +633,7 @@ match data if found. Returns nil if not within a Rust string."
   "List of builtin Rust macros for string formatting used by `rust-mode-font-lock-keywords'. (`write!' is handled separately.)")
 
 (defvar rust-formatting-macro-opening-re
-  "[[:space:]]*[({[][[:space:]]*"
+  "[[:space:]\n]*[({[][[:space:]\n]*"
   "Regular expression to match the opening delimiter of a Rust formatting macro.")
 
 (defvar rust-start-of-string-re
@@ -661,7 +661,7 @@ match data if found. Returns nil if not within a Rust string."
       1 font-lock-preprocessor-face keep)
 
      ;; Builtin formatting macros
-     (,(concat (rust-re-grab (concat (regexp-opt rust-builtin-formatting-macros) "!")) (concat rust-formatting-macro-opening-re rust-start-of-string-re))
+     (,(concat (rust-re-grab (concat (regexp-opt rust-builtin-formatting-macros) "!")) (concat rust-formatting-macro-opening-re "\\(?:" rust-start-of-string-re) "\\)?")
       (1 'rust-builtin-formatting-macro-face)
       (rust-string-interpolation-matcher
        (rust-end-of-string)


### PR DESCRIPTION
Improved the font-locking for print macros so that they still apply in cases where the body is empty, 
such as `println!()`, and when the content is on a new line.

Before:
https://i.imgur.com/b6HGC3d.png

After:
https://i.imgur.com/TGNXlMN.png