### PR TITLE
remove old-style compilation regex; support `:::` regex

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1585,10 +1585,12 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
 See `compilation-error-regexp-alist' for help on their format.")
 
 (defvar rustc-colon-compilation-regexps
-  (let ((file "\\([^\n]+\\)"))
-    (let ((re (concat "^ *::: " file ; ::: foo/bar.rs
+  (let ((file "\\([^\n]+\\)")
+        (start-line "\\([0-9]+\\)")
+        (start-col  "\\([0-9]+\\)"))
+    (let ((re (concat "^ *::: " file ":" start-line ":" start-col ; ::: foo/bar.rs
                       )))
-      (cons re '(1))))
+      (cons re '(1 2 3))))
   "Specifications for matching `:::` hints in rustc invocations.
 See `compilation-error-regexp-alist' for help on their format.")
 


### PR DESCRIPTION
The "new-style" error messages are pretty well ingrained by this point, I think.

This also adds a new regex that makes it possible to select the `:::`-style notes that arise from errors inside of macro invocations (see screen shot below):

```
error[E0026]: struct `traits::query::normalize::NormalizationResult` does not have a field named `ambiguity`
   --> src/librustc/macros.rs:255:28
    |
214 | |         }
    | |________________________________^ struct `traits::query::normalize::NormalizationResult` does not have field `ambiguity`
...
255 |                   let $s { $($field,)* } = self;
    |  ____________________________^
    |
   ::: src/librustc/traits/query/normalize.rs
    |
212 | / BraceStructTypeFoldableImpl! {
213 | |     impl<'tcx> TypeFoldable<'tcx> for NormalizationResult<'tcx> {
214 | |         normalized_ty, ambiguity
215 | |     }
216 | | }
    | |_- in this macro invocation
```

<img width="918" alt="screen shot 2018-02-15 at 5 04 02 am" src="https://user-images.githubusercontent.com/155238/36251021-acdcb86e-120d-11e8-9c55-6e9ae11787cc.png">
