### PR TITLE
Fixed indent when ? operator is used in chained method calls

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1668,12 +1668,36 @@ fn main() {
 "
    )))
 
+(ert-deftest indent-method-chains-no-align-with-question-mark-operator ()
+  (let ((rust-indent-method-chain nil)) (test-indent
+   "
+fn main() {
+    let x = thing.do_it()
+        .aligned()
+        .more_alignment()?
+        .more_alignment();
+}
+"
+   )))
+
 (ert-deftest indent-method-chains-with-align ()
   (let ((rust-indent-method-chain t)) (test-indent
    "
 fn main() {
     let x = thing.do_it()
                  .aligned()
+                 .more_alignment();
+}
+"
+   )))
+
+(ert-deftest indent-method-chains-with-align-with-question-mark-operator ()
+  (let ((rust-indent-method-chain t)) (test-indent
+   "
+fn main() {
+    let x = thing.do_it()
+                 .aligned()
+                 .more_alignment()?
                  .more_alignment();
 }
 "

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -320,7 +320,7 @@ buffer."
                 (- (current-column) rust-indent-offset)))))
         (cond
          ;; foo.bar(...)
-         ((rust-looking-back-str ")")
+         ((looking-back "[)?]" (1- (point)))
           (backward-list 1)
           (funcall skip-dot-identifier))
 
@@ -501,7 +501,7 @@ buffer."
                           ;; ..or if the previous line ends with any of these:
                           ;;     { ? : ( , ; [ }
                           ;; then we are at the beginning of an expression, so stay on the baseline...
-                          (looking-back "[(,:;?[{}]\\|[^|]|" (- (point) 2))
+                          (looking-back "[(,:;[{}]\\|[^|]|" (- (point) 2))
                           ;; or if the previous line is the end of an attribute, stay at the baseline...
                           (progn (rust-rewind-to-beginning-of-current-level-expr) (looking-at "#")))))
                       baseline


### PR DESCRIPTION
Fixes issue #259 