### PR TITLE
Fix window scrolling after rustfmt is run

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1466,14 +1466,14 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
                         (rust--format-get-loc buffer start)
                         (rust--format-get-loc buffer point))
                   window-loc)))))
-    (defvar w-start)
     (unwind-protect
         ;; save and restore window start position
         ;; after reformatting
         ;; to avoid the disturbing scrolling
-        (setq w-start (window-start))
-      (rust--format-call (current-buffer))
-      (set-window-start (selected-window) w-start)
+        (let ((w-start (window-start)))
+          (rust--format-call (current-buffer))
+          (set-window-start (selected-window) w-start)
+          )
       (dolist (loc buffer-loc)
         (let* ((buffer (pop loc))
                (pos (rust--format-get-pos buffer (pop loc))))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1466,12 +1466,12 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
                         (rust--format-get-loc buffer start)
                         (rust--format-get-loc buffer point))
                   window-loc)))))
+    (defvar w-start)
     (unwind-protect
         ;; save and restore window start position
         ;; after reformatting
         ;; to avoid the disturbing scrolling
-        (defvar w-start)
-      (setq w-start (window-start))
+        (setq w-start (window-start))
       (rust--format-call (current-buffer))
       (set-window-start (selected-window) w-start)
       (dolist (loc buffer-loc)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1467,7 +1467,13 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
                         (rust--format-get-loc buffer point))
                   window-loc)))))
     (unwind-protect
-        (rust--format-call (current-buffer))
+        ;; save and restore window start position
+        ;; after reformatting
+        ;; to avoid the disturbing scrolling
+        (defvar w-start)
+      (setq w-start (window-start))
+      (rust--format-call (current-buffer))
+      (set-window-start (selected-window) w-start)
       (dolist (loc buffer-loc)
         (let* ((buffer (pop loc))
                (pos (rust--format-get-pos buffer (pop loc))))


### PR DESCRIPTION
Hello,

I tried investigating the window scrolling after rustfmt is run (this issue has been referenced in various forms in issues #268 #231 #251) as I am still experiencing it and imo it's pretty annoying.

I'm not an elisp expert, but I think a quick fix/workaround could be to simply nail the window start position and restore it after rustfmt has finished.

I think there may be still cases where the code reformatting can be a bit confusing (f.e. `rustfmt`'ing a big messed up file), but at least I'm not getting mad every time I compulsively save a buffer :-)

Can you let me know what you think of this little patch? I tested it a bit and it has greatly improved my coding experience with rustfmt.

Thanks for your time!

EDIT: I did some checks, but I'm not sure how to fix those warning that make the CI fail
EDIT2: maybe fixed (not sure if fix is correct though)