### PR TITLE
Improve lambda list highlight

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1333,6 +1333,16 @@ list of substrings of `STR' each followed by its face."
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face)))
 
+(ert-deftest font-lock-lambda-list ()
+  (rust-test-font-lock
+   "fn foo(bar : Typ, baz: u32) {}"
+   '("fn" font-lock-keyword-face
+     "foo" font-lock-function-name-face
+     "bar" font-lock-variable-name-face
+     "Typ" font-lock-type-face
+     "baz" font-lock-variable-name-face
+     "u32" font-lock-type-face)))
+
 (ert-deftest font-lock-single-quote-character-literal ()
   (rust-test-font-lock
    "fn main() { let ch = '\\''; }"

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -680,8 +680,8 @@ match data if found. Returns nil if not within a Rust string."
      (,(concat (rust-re-grab (concat rust-re-ident "!")) "[({[:space:][]")
       1 font-lock-preprocessor-face)
 
-     ;; Field names like `foo:`, highlight excluding the :
-     (,(concat (rust-re-grab rust-re-ident) ":[^:]") 1 font-lock-variable-name-face)
+     ;; Field names or function arguments like `foo:`, highlight excluding the :
+     (,(concat (rust-re-grab rust-re-ident) "[[:space:]]*:[^:]") 1 font-lock-variable-name-face)
 
      ;; CamelCase Means Type Or Constructor
      (,rust-re-type-or-constructor 1 font-lock-type-face)


### PR DESCRIPTION
Currently, in

``` rust
    fn foo(bar : Typ, baz: u32) {}
```

baz is correctly highlighted as a variable name while bar is not.

This PR addresses that.