### PR TITLE
Add auto pairing support for `|' in elec-pair.

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -21,6 +21,7 @@
 (require 'json)
 
 (defvar electric-pair-inhibit-predicate)
+(defvar electric-pair-pairs)
 (defvar electric-indent-chars)
 
 (defvar rust-buffer-project)
@@ -1529,6 +1530,11 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (setq-local comment-end   "")
   (setq-local indent-tabs-mode nil)
   (setq-local open-paren-in-column-0-is-defun-start nil)
+
+  ;; Auto pairing of ||
+  (eval-after-load 'elec-pair
+    '(unless (assoc ?\| electric-pair-pairs)
+       (push (cons ?\| ?\|) electric-pair-pairs)))
 
   ;; Auto indent on }
   (setq-local


### PR DESCRIPTION
When using the package elec-pair, the matching `|' gets inserted like
for other parenthesis-like characters.


fix #285