### PR TITLE
compilation regexps: Match line before, too.

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1590,7 +1590,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (let ((file "\\([^\n]+\\)")
         (start-line "\\([0-9]+\\)")
         (start-col  "\\([0-9]+\\)"))
-    (let ((re (concat "^ *--> " file ":" start-line ":" start-col ; --> 1:2:3
+    (let ((re (concat "^.*\n *--> " file ":" start-line ":" start-col ; --> 1:2:3
                       )))
       (cons re '(1 2 3))))
   "Specifications for matching errors in rustc invocations.


### PR DESCRIPTION
"New format" (since 2016) Rust error messages look like this:

  error[E0308]: mismatched types
     --> src/bin/e19b.rs:672:47
      |
  672 |                 ExprRef::new(0, Nt(NT{ args : others, ..x_nt })),
      |                                               ^^^^^^ expected struct `ExprRef`, found enum `ExprCore`
      |
      = note: expected type `std::vec::Vec<ExprRef>`
		 found type `std::vec::Vec<ExprCore>`

The regexp matches the line with the `-->'.  But of course next-error
scrolls the window so the start of the regexp is at the top of the
buffer.  So we must match the line before, too.  Rust won't ever start
its messages with a `-->' so we can unconditionally include the
previous line in the match.

Signed-off-by: Ian Jackson <ijackson@chiark.greenend.org.uk>