### PR TITLE
Add rust-indent-return-type-to-arguments defcustom variable

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -450,6 +450,17 @@ fn foo4(a:i32,
 }
 "))
 
+(ert-deftest indent-return-type-non-visual ()
+  (let ((rust-indent-return-type-to-arguments nil))
+(test-indent
+   "
+fn imagine_long_enough_to_wrap_at_arrow(a:i32, b:char)
+    -> i32
+{
+    let body;
+}
+")))
+
 (ert-deftest indent-body-after-where ()
   (let ((rust-indent-where-clause t))
     (test-indent

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -131,6 +131,13 @@ When nil, `where' will be aligned with `fn' or `trait'."
   :group 'rust-mode
   :safe #'booleanp)
 
+(defcustom rust-indent-return-type-to-arguments t
+  "Indent a line starting with the `->' (RArrow) following a function, aligning
+to the function arguments.  When nil, `->' will be indented one level."
+  :type 'boolean
+  :group 'rust-mode
+  :safe #'booleanp)
+
 (defcustom rust-playpen-url-format "https://play.rust-lang.org/?code=%s"
   "Format string to use when submitting code to the playpen."
   :type 'string
@@ -399,8 +406,10 @@ buffer."
                        (back-to-indentation)
                        (current-column))))))
 
-              ;; A function return type is indented to the corresponding function arguments
-              ((looking-at "->")
+              ;; A function return type is indented to the corresponding
+	      ;; function arguments, if -to-arguments is selected.
+              ((and rust-indent-return-type-to-arguments
+		    (looking-at "->"))
                (save-excursion
                  (backward-list)
                  (or (rust-align-to-expr-after-brace)


### PR DESCRIPTION
This adds a user customizable setting which defaults (t) to the current behavior for `-> ReturnType` on its own line, which is indenting to the same column as the arguments of the associated function. 

When disabled (nil) by the user, however, this will now just indent such a line one level from its baseline (no special treatment).

For example, the existing and default indentation:
```rust
pub fn fetch<B: hyper::body::Payload>(rr: RequestRecord<B>, tune: &Tunables)
                                      -> Result<Dialog, Flare>
{
    //...
}
```

With this change, and disabled (set nil) by the user:
```rust
pub fn fetch<B: hyper::body::Payload>(rr: RequestRecord<B>, tune: &Tunables)
    -> Result<Dialog, Flare>
{
    //...
}
```
The former appears to accommodate a visual-indent style for functions, and I suspect it predates the rustfmt and fmt-RFCs moving firmly away from visual-indent style? The fmt-RFCs also don't advertise the desirability of a line-break before `->`, but some existing code, including my own, finds a line-break here convenient. 

Includes a basic test.