### PR TITLE
Add compilation mode warning face

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1599,8 +1599,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (let ((file "\\([^\n]+\\)")
         (start-line "\\([0-9]+\\)")
         (start-col  "\\([0-9]+\\)"))
-    (let ((re (concat "^\\(?:error\\|\\(warning\\)\\)[^-]+--> \\(" file ":" start-line ":" start-col "\\)" ; --> 1:2:3
-                      )))
+    (let ((re (concat "^\\(?:error\\|\\(warning\\)\\)[^-]+--> \\(" file ":" start-line ":" start-col "\\)")))
       (cons re '(3 4 5 (1) 2))))
   "Specifications for matching errors in rustc invocations.
 See `compilation-error-regexp-alist' for help on their format.")

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1594,14 +1594,14 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (when rust-format-on-save
     (unless (executable-find rust-rustfmt-bin)
       (error "Could not locate executable \"%s\"" rust-rustfmt-bin))))
-  
+
 (defvar rustc-compilation-regexps
   (let ((file "\\([^\n]+\\)")
         (start-line "\\([0-9]+\\)")
         (start-col  "\\([0-9]+\\)"))
-    (let ((re (concat "^ *--> " file ":" start-line ":" start-col ; --> 1:2:3
+    (let ((re (concat "^\\(?:error\\|\\(warning\\)\\)[^-]+--> \\(" file ":" start-line ":" start-col "\\)" ; --> 1:2:3
                       )))
-      (cons re '(1 2 3))))
+      (cons re '(3 4 5 (1) 2))))
   "Specifications for matching errors in rustc invocations.
 See `compilation-error-regexp-alist' for help on their format.")
 


### PR DESCRIPTION
This updates the compilation mode regex so that warnings are colored properly,
making them easier to differentiate from errors.

Before:
https://i.imgur.com/mChGm3k.png

After:
https://i.imgur.com/hBXjGk0.png