### PR TITLE
Avoid signaling "Beginning of buffer" in rust-looking-back-macro

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1234,7 +1234,7 @@ fn test4();")
   (with-temp-buffer
     (rust-mode)
     (insert str)
-    (font-lock-ensure)
+    (font-lock-fontify-buffer)
     (buffer-string)))
 
 (defun rust-test-group-str-by-face (str)
@@ -1503,7 +1503,7 @@ this_is_not_a_string();)"
 1......................500......................50
 \"#;
 ")
-    (font-lock-ensure)
+    (font-lock-fontify-buffer)
     (goto-char 530)
     (insert "#")
     ;; We have now closed the raw string.  Check that the whole string is
@@ -1880,7 +1880,7 @@ fn indented_already() {
     \n    // The previous line already has its spaces
 }
 ")
-    (font-lock-ensure)
+    (font-lock-fontify-buffer)
     (goto-line 11)
     (move-to-column 0)
     (indent-for-tab-command)
@@ -2115,7 +2115,7 @@ fn main() {
   (with-temp-buffer
     (rust-mode)
     (insert content)
-    (font-lock-ensure)
+    (font-lock-fontify-buffer)
     (dolist (pair pairs)
       (let* ((open-pos (nth 0 pair))
              (close-pos (nth 1 pair)))
@@ -2148,7 +2148,7 @@ fn main() {
 (ert-deftest rust-test-two-character-quotes-in-a-row ()
   (with-temp-buffer
     (rust-mode)
-    (font-lock-ensure)
+    (font-lock-fontify-buffer)
     (insert "'\\n','a', fn")
     (font-lock-after-change-function 1 12 0)
 
@@ -3116,7 +3116,7 @@ impl Two<'a> {
           (with-temp-buffer
             (rust-mode)
             (insert original)
-            (font-lock-ensure)
+            (font-lock-fontify-buffer)
 
             (goto-char point-pos)
             (deactivate-mark)

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2414,6 +2414,14 @@ fn main() {
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face)))
 
+(ert-deftest font-lock-fontify-angle-brackets ()
+    "Test that angle bracket fontify"
+    (should (equal (rust-test-fontify-string "<>") "<>"))
+    (should (equal (rust-test-fontify-string "<foo>") "<foo>"))
+    (should (equal (rust-test-fontify-string "<<>>") "<<>>"))
+    (should (equal (rust-test-fontify-string "<>>") "<>>"))
+    (should (equal (rust-test-fontify-string "<<>") "<<>")))
+
 (ert-deftest rust-test-basic-paren-matching ()
   (rust-test-matching-parens
    "

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1234,7 +1234,7 @@ fn test4();")
   (with-temp-buffer
     (rust-mode)
     (insert str)
-    (font-lock-fontify-buffer)
+    (font-lock-ensure)
     (buffer-string)))
 
 (defun rust-test-group-str-by-face (str)
@@ -1503,7 +1503,7 @@ this_is_not_a_string();)"
 1......................500......................50
 \"#;
 ")
-    (font-lock-fontify-buffer)
+    (font-lock-ensure)
     (goto-char 530)
     (insert "#")
     ;; We have now closed the raw string.  Check that the whole string is
@@ -1880,7 +1880,7 @@ fn indented_already() {
     \n    // The previous line already has its spaces
 }
 ")
-    (font-lock-fontify-buffer)
+    (font-lock-ensure)
     (goto-line 11)
     (move-to-column 0)
     (indent-for-tab-command)
@@ -2115,7 +2115,7 @@ fn main() {
   (with-temp-buffer
     (rust-mode)
     (insert content)
-    (font-lock-fontify-buffer)
+    (font-lock-ensure)
     (dolist (pair pairs)
       (let* ((open-pos (nth 0 pair))
              (close-pos (nth 1 pair)))
@@ -2148,7 +2148,7 @@ fn main() {
 (ert-deftest rust-test-two-character-quotes-in-a-row ()
   (with-temp-buffer
     (rust-mode)
-    (font-lock-fontify-buffer)
+    (font-lock-ensure)
     (insert "'\\n','a', fn")
     (font-lock-after-change-function 1 12 0)
 
@@ -3108,7 +3108,7 @@ impl Two<'a> {
           (with-temp-buffer
             (rust-mode)
             (insert original)
-            (font-lock-fontify-buffer)
+            (font-lock-ensure)
 
             (goto-char point-pos)
             (deactivate-mark)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -80,7 +80,7 @@ Like `looking-back' but for fixed strings rather than regexps (so that it's not 
 
 (defun rust-looking-back-macro ()
   "Non-nil if looking back at an ident followed by a !"
-  (if (> (point) 2)
+  (if (> (- (point) (point-min)) 1)
       (save-excursion (backward-char) (and (= ?! (char-after)) (rust-looking-back-ident)))))
 
 ;; Syntax definitions and helpers

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -80,7 +80,8 @@ Like `looking-back' but for fixed strings rather than regexps (so that it's not 
 
 (defun rust-looking-back-macro ()
   "Non-nil if looking back at an ident followed by a !"
-  (save-excursion (backward-char) (and (= ?! (char-after)) (rust-looking-back-ident))))
+  (if (> (point) 2)
+      (save-excursion (backward-char) (and (= ?! (char-after)) (rust-looking-back-ident)))))
 
 ;; Syntax definitions and helpers
 (defvar rust-mode-syntax-table
@@ -1594,7 +1595,7 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (when rust-format-on-save
     (unless (executable-find rust-rustfmt-bin)
       (error "Could not locate executable \"%s\"" rust-rustfmt-bin))))
-  
+
 (defvar rustc-compilation-regexps
   (let ((file "\\([^\n]+\\)")
         (start-line "\\([0-9]+\\)")


### PR DESCRIPTION
Also save some work if we don't have at least two characters behind us
in the buffer, we know we can't be looking at a macro then. The signal
occurs when one tries 'racer-describe' when positioned over "String",
which eventually ends up calling

(with-temp-buffer
  (insert "<Target=str>")
  (delay-mode-hooks (rust-mode))
  (font-lock-ensure))

This simpler block will also trigger the error

(with-temp-buffer
  (insert "<>")
  (rust-mode)
  (font-lock-ensure))

(font-lock-ensure) call ends up calling (rust-looking-back-macro).