### PR TITLE
 Handle attributes in mark-defun / beginning-of-defun. 

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -964,6 +964,12 @@ Convert the line-column information from that list into a buffer position value.
       (move-to-column column)
       (point))))
 
+(defun buffer-pos (pos)
+  "Convert POS into a list (LINE COLUMN) of the current buffer."
+  (save-excursion
+    (goto-char pos)
+    (list (line-number-at-pos) (current-column))))
+
 ;;; FIXME: Maybe add an ERT explainer function (something that shows the
 ;;; surrounding code of the final point, not just the position).
 (defun rust-test-motion (source-code init-pos final-pos manip-func &rest args)
@@ -977,7 +983,8 @@ INIT-POS, FINAL-POS are position symbols found in `rust-test-positions-alist'."
     (insert source-code)
     (goto-char (rust-get-buffer-pos init-pos))
     (apply manip-func args)
-    (should (equal (point) (rust-get-buffer-pos final-pos)))))
+    (should (equal (buffer-pos (point))
+                   (buffer-pos (rust-get-buffer-pos final-pos))))))
 
 (defun rust-test-region (source-code init-pos reg-beg reg-end manip-func &rest args)
   "Test that MANIP-FUNC marks region from REG-BEG to REG-END.
@@ -990,9 +997,10 @@ All positions are position symbols found in `rust-test-positions-alist'."
     (insert source-code)
     (goto-char (rust-get-buffer-pos init-pos))
     (apply manip-func args)
-    (should (equal (list (region-beginning) (region-end))
-                   (list (rust-get-buffer-pos reg-beg)
-                         (rust-get-buffer-pos reg-end))))))
+    (should (equal (list (buffer-pos (region-beginning))
+                         (buffer-pos (region-end)))
+                   (list (buffer-pos (rust-get-buffer-pos reg-beg))
+                         (buffer-pos (rust-get-buffer-pos reg-end)))))))
 
 (ert-deftest rust-beginning-of-defun-from-middle-of-fn ()
   (rust-test-motion

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -31,7 +31,19 @@
   (unless (fboundp 'setq-local)
     (defmacro setq-local (var val)
       "Set variable VAR to value VAL in current buffer."
-      (list 'set (list 'make-local-variable (list 'quote var)) val))))
+      (list 'set (list 'make-local-variable (list 'quote var)) val)))
+
+  (unless (fboundp 'gensym)
+    (defvar rust-gensym-counter 0
+      "Number used to construct the name of the next symbol created by `gensym'.")
+    
+    (defun gensym (&optional prefix)
+      "Return a new uninterned symbol.
+The name is made by appending `rust-gensym-counter' to PREFIX.
+PREFIX is a string, and defaults to \"g\"."
+      (let ((num (prog1 rust-gensym-counter
+		   (setq rust-gensym-counter (1+ rust-gensym-counter)))))
+	(make-symbol (format "%s%d" (or prefix "g") num))))))
 
 (defconst rust-re-ident "[[:word:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*")
 (defconst rust-re-lc-ident "[[:lower:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*")

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1302,7 +1302,7 @@ Use idomenu (imenu with `ido-mode') for best mileage.")
 
 ;;; Defun Motions
 
-(defmacro repeat-while-point-moves (&rest body)
+(defmacro rust-repeat-while-point-moves (&rest body)
   (let ((opoint (gensym "opoint")))
     `(let ((,opoint (point)))
        (while (progn (progn ,@body)
@@ -1339,7 +1339,7 @@ which calls this, does that afterwards."
 
 (defun rust-backward-attributes ()
   "Move the point to the start of the attributes preceding point."
-  (repeat-while-point-moves (rust-backward-attribute)))
+  (rust-repeat-while-point-moves (rust-backward-attribute)))
 
 (defun rust-backward-attribute ()
   "Move the point to the start of the preceding attribute.
@@ -1366,7 +1366,7 @@ Comments are skipped."
 
 (defun rust-skip-comments ()
   "Skip forward all comments following the point."
-  (repeat-while-point-moves (forward-comment 1)))
+  (rust-repeat-while-point-moves (forward-comment 1)))
 
 (defun rust-end-of-defun ()
   "Move forward to the next end of defun.

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -61,7 +61,7 @@ PREFIX is a string, and defaults to \"g\"."
     (+ space) (regexp ,rust-re-ident))))
 
 (defconst rust-attribute-re
-  "#\\[[[:word:]\\|(\\)\\|,\\[:space:]]+]")
+  "#\\[[[:word:](),[:space:]]+]")
 
 ;;; Start of a Rust item
 (defvar rust-top-item-beg-re


### PR DESCRIPTION
Typical scenario where this can be useful: 

I want to mark a test (of a type with a bunch of derive statements) to move some code around. Calling mark-defun (C-M-h) does not select the attribute (`#[test]` or `#[derive(...)]`, respectively).

This tries to fix this state of affair.