### PR TITLE
Update Debian installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the packages for you (under `~/.emacs.d/elpa/`).
 
 * or using <kbd>M-x package-install rust-mode</kbd>
 
-### Package installation on Debian testing or unstable
+### Package installation on Debian
 
 ```bash
 apt install elpa-rust-mode


### PR DESCRIPTION
`rust-mode` is now included in Debian stable, so don't limit the Debian installation instructions to only testing and unstable.