### PR TITLE
Feature/update emacs versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: generic
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,15 @@
 language: generic
 
 env:
-  matrix:
-    - EMACS=emacs24
-    - EMACS=emacs-snapshot
-
+ - EVM_EMACS=emacs-25.1-travis
+ - EVM_EMACS=emacs-25.2-travis
+ - EVM_EMACS=emacs-25.3-travis
+ - EVM_EMACS=emacs-26.1-travis
+ - EVM_EMACS=emacs-26.2-travis
+ - EVM_EMACS=emacs-git-snapshot-travis
 install:
-  - if [ "$EMACS" = 'emacs24' ]; then
-       sudo add-apt-repository -y ppa:cassou/emacs &&
-       sudo apt-get -qq update &&
-       sudo apt-get -qq -f install &&
-       sudo apt-get -qq install emacs24 emacs24-el;
-    fi
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
-       sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
-       sudo apt-get -qq update &&
-       sudo apt-get -qq -f install &&
-       sudo apt-get -qq install emacs-snapshot &&
-       sudo apt-get -qq install emacs-snapshot-el;
-    fi
-
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > travis.sh && source ./travis.sh
+  - evm install $EVM_EMACS --use --skip
 script:
   - ./run_rust_emacs_tests.sh
 

--- a/run_rust_emacs_tests_docker.sh
+++ b/run_rust_emacs_tests_docker.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+echo "Testing Local files with Emacs 26 (latest)"
+docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:26.2-dev ./test-by-cp
+
+echo Testing Local files with Emacs 25
+docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:25.3-dev ./test-by-cp
+
+echo "Testing Local files with Emacs 24 (oldest)"
+docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:24.5-dev ./test-by-cp
+
+echo "Testing commits with Emacs 26 (latest)"
+docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:26.2-dev ./test-from-git
+
+echo Testing commits with Emacs 25
+docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:25.3-dev ./test-from-git
+
+echo "Testing commits with Emacs 24 (oldest)"
+docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:24.5-dev ./test-from-git
+
+

--- a/test-by-cp
+++ b/test-by-cp
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd ..
+mkdir copy
+cd copy
+cp -rf ../app/* .
+./run_rust_emacs_tests.sh

--- a/test-from-git
+++ b/test-from-git
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd ..
+mkdir git
+cd git
+git clone ../app .
+./run_rust_emacs_tests.sh


### PR DESCRIPTION
Following on from the discussion here:

https://github.com/rust-lang/rust-mode/pull/309

This adds a updated test environment. A local docker based test is added, and all versions 25 and 26 versions are supported.