### PR TITLE
Don't set indent-tabs-mode.

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -6,6 +6,7 @@
 (require 'imenu)
 
 (setq rust-test-fill-column 32)
+(setq-default indent-tabs-mode nil)
 
 (defun rust-compare-code-after-manip (original point-pos manip-func expected got)
   (equal expected got))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1583,7 +1583,6 @@ Return the created process."
   ;; Misc
   (setq-local comment-start "// ")
   (setq-local comment-end   "")
-  (setq-local indent-tabs-mode nil)
   (setq-local open-paren-in-column-0-is-defun-start nil)
 
   ;; Auto indent on }


### PR DESCRIPTION
rust-mode should not prevent users to use tabs if they want to; if indent-tabs-mode is configured, don't change it.

Fix #312.