### PR TITLE
rust-mode.el: check for possible space between variable name and type

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -3108,6 +3108,16 @@ impl Two<'a> {
    '(("Impl" "One" "Two")
      ("Fn" "one" "two"))))
 
+(ert-deftest font-lock-function-parameters ()
+  (rust-test-font-lock
+   "fn foo(a: u32, b : u32) {}"
+   '("fn" font-lock-keyword-face
+     "foo" font-lock-function-name-face
+     "a" font-lock-variable-name-face
+     "u32" font-lock-type-face
+     "b" font-lock-variable-name-face
+     "u32" font-lock-type-face)))
+
 (when (executable-find rust-cargo-bin)
   (ert-deftest rust-test-project-located ()
     (lexical-let* ((test-dir (expand-file-name "test-project" default-directory))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -694,7 +694,7 @@ Returns nil if the point is not within a Rust string."
       1 font-lock-preprocessor-face)
 
      ;; Field names like `foo:`, highlight excluding the :
-     (,(concat (rust-re-grab rust-re-ident) ":[^:]") 1 font-lock-variable-name-face)
+     (,(concat (rust-re-grab rust-re-ident) "[[:space:]]*:[^:]") 1 font-lock-variable-name-face)
 
      ;; CamelCase Means Type Or Constructor
      (,rust-re-type-or-constructor 1 font-lock-type-face)


### PR DESCRIPTION
Fixes the following problem: consider code

    fn foo(a: u32, b : u32) {}

Here, `b` was not highlighted as a variable, because the regex didn't
take into account possible space before the colon.

Signed-off-by: Konstantin Kharlamov <Hi-Angel@yandex.ru>