### PR TITLE
Suggest setting indent-tabs-mode to nil in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - [Installation via MELPA](#installation-via-melpa)
 - [Manual Installation](#manual-installation)
+- [Indentation](#indentation)
 - [rustfmt](#rustfmt)
 - [Tests](#tests)
 - [Other useful packages](#other-useful-packages)
@@ -42,6 +43,16 @@ Add this to your init.el:
 ``` elisp
 (add-to-list 'load-path "/path/to/rust-mode/")
 (autoload 'rust-mode "rust-mode" nil t)
+```
+
+# Indentation
+
+The Rust style guide recommends spaces for indentation; to follow the
+recommendation add this to your init.el:
+
+```elisp
+(add-hook 'rust-mode-hook
+          (lambda () (setq indent-tabs-mode nil)))
 ```
 
 # rustfmt

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ And put this in your config to load rust-mode automatically:
 
 `(require 'rust-mode)`
 
-# Manual Installation 
+# Manual Installation
 
 Add this to your init.el:
 
@@ -58,7 +58,7 @@ recommendation add this to your init.el:
 # rustfmt
 
 The `rust-format-buffer` function will format your code with
-[rustfmt](https://github.com/rust-lang/rustfmt) if installed. By default, 
+[rustfmt](https://github.com/rust-lang/rustfmt) if installed. By default,
 this is bound to `C-c C-f`.
 
 Placing `(setq rust-format-on-save t)` in your init.el will enable automatic
@@ -73,6 +73,6 @@ you set the environment variable EMACS to a program that runs emacs.
 
 # Other useful packages
 
-[cargo.el](https://github.com/kwrooijen/cargo.el) Emacs Minor Mode for Cargo, Rust's Package Manager
-[emacs-racer](https://github.com/racer-rust/emacs-racer) Racer support for Emacs
-[rustic](https://github.com/brotzeit/rustic) Rust development environment for Emacs 
+* [cargo.el](https://github.com/kwrooijen/cargo.el) Emacs Minor Mode for Cargo, Rust's Package Manager
+* [emacs-racer](https://github.com/racer-rust/emacs-racer) Racer support for Emacs
+* [rustic](https://github.com/brotzeit/rustic) Rust development environment for Emacs


### PR DESCRIPTION
The second commit makes sure that `~/.emacs.d/init.el` is referred to consistently in the README.

Closes #330.