### PR TITLE
Do not allow subword-match when detecting built-in formatting macros

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2426,7 +2426,15 @@ fn main() {
      "{1}" rust-string-interpolation-face
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
-     "no-op */" font-lock-comment-face)))
+     "no-op */" font-lock-comment-face))
+  (rust-test-font-lock
+   "println!(\"123\"); eprintln!(\"123\"); cprintln!(\"123\");"
+   '("println!" rust-builtin-formatting-macro-face
+     "\"123\"" font-lock-string-face
+     "eprintln!" rust-builtin-formatting-macro-face
+     "\"123\"" font-lock-string-face
+     "cprintln!" font-lock-preprocessor-face
+     "\"123\"" font-lock-string-face)))
 
 (ert-deftest font-lock-fontify-angle-brackets ()
     "Test that angle bracket fontify"

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -676,7 +676,7 @@ Returns nil if the point is not within a Rust string."
       1 font-lock-preprocessor-face keep)
 
      ;; Builtin formatting macros
-     (,(concat (rust-re-grab (concat (regexp-opt rust-builtin-formatting-macros) "!")) (concat rust-formatting-macro-opening-re "\\(?:" rust-start-of-string-re) "\\)?")
+     (,(concat (rust-re-grab (concat (rust-re-word (regexp-opt rust-builtin-formatting-macros)) "!")) (concat rust-formatting-macro-opening-re "\\(?:" rust-start-of-string-re) "\\)?")
       (1 'rust-builtin-formatting-macro-face)
       (rust-string-interpolation-matcher
        (rust-end-of-string)
@@ -684,7 +684,7 @@ Returns nil if the point is not within a Rust string."
        (0 'rust-string-interpolation-face t nil)))
 
      ;; write! macro
-     (,(concat (rust-re-grab "write\\(ln\\)?!") (concat rust-formatting-macro-opening-re "[[:space:]]*[^\"]+,[[:space:]]*" rust-start-of-string-re))
+     (,(concat (rust-re-grab (concat (rust-re-word "write\\(ln\\)?") "!")) (concat rust-formatting-macro-opening-re "[[:space:]]*[^\"]+,[[:space:]]*" rust-start-of-string-re))
       (1 'rust-builtin-formatting-macro-face)
       (rust-string-interpolation-matcher
        (rust-end-of-string)


### PR DESCRIPTION
Continuation of #297, adding some tests.

close #297