### PR TITLE
Fix rust-insert-dbg for emacs-version < 25.

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1805,8 +1805,11 @@ visit the new file."
 (defun rust-insert-dbg ()
   "Insert the dbg! macro."
   (cond ((region-active-p)
-         (insert-parentheses)
-         (backward-char 1))
+         (when (< (mark) (point))
+           (exchange-point-and-mark))
+         (let ((old-point (point)))
+           (insert-parentheses)
+           (goto-char old-point)))
         (t
          (insert "(")
          (forward-sexp)


### PR DESCRIPTION
The behaviour of insert-parenthesis changed with emacs 25: 

+ point and mark are not exchanged, even if out of order
+ the point ends up before the opening parenthesis in emacs 24.5, while after it on 25.1.

Hence this fix.