### PR TITLE
rust-insert-dbg: handle the case of string literals.

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -245,10 +245,6 @@ fn bar() { }"
 /// even more.
 fn bar() { }" 14 85))
 
-(defun test-dbg-wrap (initial expected position &optional end)
-  (with-temp-buffer
-    (insert initial)))
-
 (defun test-auto-fill (initial position inserted expected)
   (rust-test-manip-code
    initial
@@ -3185,6 +3181,13 @@ impl Two<'a> {
 
 (ert-deftest rust-test-dbg-uwnrap-on-dbg-start ()
   (rust-test-dbg-unwrap 13))
+
+(ert-deftest rust-test-dbg-unwrap-inside-string-literal ()
+  (rust-test-manip-code
+   "let x = \"foo, bar\"";"
+   15
+   #'rust-dbg-wrap-or-unwrap
+   "let x = dbg!(\"foo, bar\")"))
 
 (when (executable-find rust-cargo-bin)
   (ert-deftest rust-test-project-located ()

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1812,12 +1812,76 @@ visit the new file."
            (goto-char old-point)))
         (t
          (when (rust-in-str)
-           (backward-up-list nil t t))
+           (rust--up-list -1 t t))
          (insert "(")
          (forward-sexp)
          (insert ")")
          (backward-sexp)))
   (insert "dbg!"))
+
+(defun rust--up-list (&optional arg escape-strings no-syntax-crossing)
+  "Compatibility for emacs 24."
+  (or arg (setq arg 1))
+  (let ((inc (if (> arg 0) 1 -1))
+        (pos nil))
+    (while (/= arg 0)
+      (condition-case err
+          (save-restriction
+            ;; If we've been asked not to cross string boundaries
+            ;; and we're inside a string, narrow to that string so
+            ;; that scan-lists doesn't find a match in a different
+            ;; string.
+            (when no-syntax-crossing
+              (let* ((syntax (syntax-ppss))
+                     (string-comment-start (nth 8 syntax)))
+                (when string-comment-start
+                  (save-excursion
+                    (goto-char string-comment-start)
+                    (narrow-to-region
+                     (point)
+                     (if (nth 3 syntax) ; in string
+                         (condition-case nil
+                             (progn (forward-sexp) (point))
+                           (scan-error (point-max)))
+                       (forward-comment 1)
+                       (point)))))))
+            (if (null forward-sexp-function)
+                (goto-char (or (scan-lists (point) inc 1)
+                               (buffer-end arg)))
+              (condition-case err
+                  (while (progn (setq pos (point))
+                                (forward-sexp inc)
+                                (/= (point) pos)))
+                (scan-error (goto-char (nth (if (> arg 0) 3 2) err))))
+              (if (= (point) pos)
+                  (signal 'scan-error
+                          (list "Unbalanced parentheses" (point) (point))))))
+        (scan-error
+         (let ((syntax nil))
+           (or
+            ;; If we bumped up against the end of a list, see whether
+            ;; we're inside a string: if so, just go to the beginning
+            ;; or end of that string.
+            (and escape-strings
+                 (or syntax (setf syntax (syntax-ppss)))
+                 (nth 3 syntax)
+                 (goto-char (nth 8 syntax))
+                 (progn (when (> inc 0)
+                          (forward-sexp))
+                        t))
+            ;; If we narrowed to a comment above and failed to escape
+            ;; it, the error might be our fault, not an indication
+            ;; that we're out of syntax.  Try again from beginning or
+            ;; end of the comment.
+            (and no-syntax-crossing
+                 (or syntax (setf syntax (syntax-ppss)))
+                 (nth 4 syntax)
+                 (goto-char (nth 8 syntax))
+                 (or (< inc 0)
+                     (forward-comment 1))
+                 (setf arg (+ arg inc)))
+            (signal (car err) (cdr err))))))
+      (setq arg (- arg inc)))))
 
 ;;;###autoload
 (defun rust-dbg-wrap-or-unwrap ()

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1811,6 +1811,8 @@ visit the new file."
            (insert-parentheses)
            (goto-char old-point)))
         (t
+         (when (rust-in-str)
+           (backward-up-list nil t t))
          (insert "(")
          (forward-sexp)
          (insert ")")


### PR DESCRIPTION
With the current code, C-c C-d from inside a string literal tries to parse the tokens around ignoring that the point is inside a string.

This PR mitigates that issue when the region is inactive: if so, start by getting out of the string.
Unfortunately, we need to vendor `up-list' for emacs 24.