### PR TITLE
rust format buffer now saves position across multiple frames

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1557,16 +1557,17 @@ Return the created process."
         (push (list buffer
                     (rust--format-get-loc buffer nil))
               buffer-loc)))
-    (dolist (window (window-list))
-      (let ((buffer (window-buffer window)))
-        (when (or (eq buffer base)
-                  (eq (buffer-base-buffer buffer) base))
-          (let ((start (window-start window))
-                (point (window-point window)))
-            (push (list window
-                        (rust--format-get-loc buffer start)
-                        (rust--format-get-loc buffer point))
-                  window-loc)))))
+    (dolist (frame (frame-list))
+      (dolist (window (window-list frame))
+	(let ((buffer (window-buffer window)))
+	  (when (or (eq buffer base)
+		    (eq (buffer-base-buffer buffer) base))
+	    (let ((start (window-start window))
+		  (point (window-point window)))
+	      (push (list window
+			  (rust--format-get-loc buffer start)
+			  (rust--format-get-loc buffer point))
+		    window-loc))))))
     (unwind-protect
         (rust--format-call (current-buffer))
       (dolist (loc buffer-loc)


### PR DESCRIPTION
This solves issue https://github.com/rust-lang/rust-mode/issues/347 by looping over every frame and then looping over the windows in each frame. 