### PR TITLE
Add rust-occur-definitions

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1378,6 +1378,29 @@ Create a hierarchical index of the item definitions in a Rust file.
 Imenu will show all the enums, structs, etc. in their own subheading.
 Use idomenu (imenu with `ido-mode') for best mileage.")
 
+;;; Occur support
+
+(defun rust-occur-definitions ()
+  "Display an occur buffer of all definitions in the current buffer."
+  (interactive)
+  (let ((list-matching-lines-face nil))
+    (occur (concat "^\s*\\("
+                   "\\(pub.*?\s\\|\\)mod\\|"
+                   "\\(pub.*?\s\\|\\)type\\|"
+                   "\\(pub.*?\s\\|\\)struct\\|"
+                   "\\(pub.*?\s\\|\\)enum\\|"
+                   "\\(pub.*?\s\\|unsafe\s\\|const\s\\|async\s\\|\\)fn\\|"
+                   "\\(pub.*?\s\\|unsafe\s\\|\\)trait\\|"
+                   "\\(pub.*?\s\\|\\)const\\|"
+                   "\\(pub.*?\s\\|\\)static\sref\\|"
+                   "lazy_static\!\\|"
+                   "impl"
+                   "\\)\s")))
+  (let ((window (get-buffer-window "*Occur*")))
+    (if window
+        (select-window window)
+      (switch-to-buffer "*Occur*"))))
+
 ;;; Defun Motions
 
 (defun rust-beginning-of-defun (&optional arg)


### PR DESCRIPTION
Taking inspiration from [elpy](https://github.com/jorgenschaefer/elpy/blob/b7396efa97c507ceb26ef479b05ec04ff382ec14/elpy.el#L2522), this function displays an occur buffer of all definitions in the current buffer.

This is similar to what `imenu` provides, but it also reflects the overall file structure (by preserving order and indentation).

It could be bound to `C-c C-o` (as done in `elpy`).