### PR TITLE
Fix stdin issue for rust--format-fix-rustfmt-buffer.

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1484,6 +1484,8 @@ This is written mainly to be used as `end-of-defun-function' for Rust."
   (with-current-buffer (get-buffer rust-rustfmt-buffername)
     (goto-char (point-min))
     (while (re-search-forward "--> <stdin>:" nil t)
+      (replace-match (format "--> %s:" buffer-name)))
+    (while (re-search-forward "--> stdin:" nil t)
       (replace-match (format "--> %s:" buffer-name)))))
 
 ;; If rust-mode has been configured to navigate to source of the error

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1534,7 +1534,7 @@ rustfmt complain in the echo area."
                                     (if (re-search-forward "\nerror:.+\n" nil t)
                                         (buffer-substring p0 (point))
                                       (buffer-substring p0 (point-max)))))))))
-        (when (and target-buffer target-point)
+        (when (and target-buffer (get-buffer target-buffer) target-point)
           (switch-to-buffer target-buffer)
           (goto-char (point-min))
           (forward-line (1- (car target-point)))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -198,7 +198,7 @@ to the function arguments.  When nil, `->' will be indented one level."
   :safe #'booleanp
   :group 'rust-mode)
 
-(defcustom rust-format-show-buffer nil
+(defcustom rust-format-show-buffer t
   "Show *rustfmt* buffer if formatting detected problems."
   :type 'boolean
   :safe #'booleanp


### PR DESCRIPTION
fix #365 
The issue seems to be that in case of whitespace issues,   rustfmt emits the message 
```
error[internal]: left behind trailing whitespace
  --> stdin:13:13:0
   |
13 |                 
   | ^^^^^^^^^^^^^^^^
   |

warning: rustfmt has failed to format. See previous 1 errors.

```

and the replacement code that looks for "<stdin>:" fails to replace the reference. As a consequence, the code that jumps to the error pops a new buffer, which is wrong.

cc @xaon @Dushistov 