### PR TITLE
Drop Emacs-24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         rust_version: [stable]
         emacs_version:
-          - 24.5
           - 25.1
           - 25.2
           - 25.3

--- a/run_rust_emacs_tests_docker.sh
+++ b/run_rust_emacs_tests_docker.sh
@@ -6,16 +6,10 @@ docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --ent
 echo Testing Local files with Emacs 25
 docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:25.3-dev ./test-by-cp
 
-echo "Testing Local files with Emacs 24 (oldest)"
-docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:24.5-dev ./test-by-cp
-
 echo "Testing commits with Emacs 26 (latest)"
 docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:26.2-dev ./test-from-git
 
 echo Testing commits with Emacs 25
 docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:25.3-dev ./test-from-git
-
-echo "Testing commits with Emacs 24 (oldest)"
-docker run -it --rm --name docker-cp -v `pwd`:/usr/src/app -w /usr/src/app --entrypoint=/bin/bash  silex/emacs:24.5-dev ./test-from-git
 
 

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -4,7 +4,7 @@
 ;; Author: Mozilla
 ;; Url: https://github.com/rust-lang/rust-mode
 ;; Keywords: languages
-;; Package-Requires: ((emacs "24.0"))
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This file is distributed under the terms of both the MIT license and the
 ;; Apache License (version 2.0).
@@ -27,13 +27,6 @@
 
 (defvar rust-buffer-project)
 (make-variable-buffer-local 'rust-buffer-project)
-
-;; for GNU Emacs < 24.3
-(eval-when-compile
-  (unless (fboundp 'setq-local)
-    (defmacro setq-local (var val)
-      "Set variable VAR to value VAL in current buffer."
-      (list 'set (list 'make-local-variable (list 'quote var)) val))))
 
 (defun rust-re-word (inner) (concat "\\<" inner "\\>"))
 (defun rust-re-grab (inner) (concat "\\(" inner "\\)"))
@@ -1983,76 +1976,12 @@ visit the new file."
            (goto-char old-point)))
         (t
          (when (rust-in-str)
-           (rust--up-list -1 t t))
+           (up-list -1 t t))
          (insert "(")
          (forward-sexp)
          (insert ")")
          (backward-sexp)))
   (insert "dbg!"))
-
-(defun rust--up-list (&optional arg escape-strings no-syntax-crossing)
-  "Compatibility for emacs 24."
-  (or arg (setq arg 1))
-  (let ((inc (if (> arg 0) 1 -1))
-        (pos nil))
-    (while (/= arg 0)
-      (condition-case err
-          (save-restriction
-            ;; If we've been asked not to cross string boundaries
-            ;; and we're inside a string, narrow to that string so
-            ;; that scan-lists doesn't find a match in a different
-            ;; string.
-            (when no-syntax-crossing
-              (let* ((syntax (syntax-ppss))
-                     (string-comment-start (nth 8 syntax)))
-                (when string-comment-start
-                  (save-excursion
-                    (goto-char string-comment-start)
-                    (narrow-to-region
-                     (point)
-                     (if (nth 3 syntax) ; in string
-                         (condition-case nil
-                             (progn (forward-sexp) (point))
-                           (scan-error (point-max)))
-                       (forward-comment 1)
-                       (point)))))))
-            (if (null forward-sexp-function)
-                (goto-char (or (scan-lists (point) inc 1)
-                               (buffer-end arg)))
-              (condition-case err
-                  (while (progn (setq pos (point))
-                                (forward-sexp inc)
-                                (/= (point) pos)))
-                (scan-error (goto-char (nth (if (> arg 0) 3 2) err))))
-              (if (= (point) pos)
-                  (signal 'scan-error
-                          (list "Unbalanced parentheses" (point) (point))))))
-        (scan-error
-         (let ((syntax nil))
-           (or
-            ;; If we bumped up against the end of a list, see whether
-            ;; we're inside a string: if so, just go to the beginning
-            ;; or end of that string.
-            (and escape-strings
-                 (or syntax (setf syntax (syntax-ppss)))
-                 (nth 3 syntax)
-                 (goto-char (nth 8 syntax))
-                 (progn (when (> inc 0)
-                          (forward-sexp))
-                        t))
-            ;; If we narrowed to a comment above and failed to escape
-            ;; it, the error might be our fault, not an indication
-            ;; that we're out of syntax.  Try again from beginning or
-            ;; end of the comment.
-            (and no-syntax-crossing
-                 (or syntax (setf syntax (syntax-ppss)))
-                 (nth 4 syntax)
-                 (goto-char (nth 8 syntax))
-                 (or (< inc 0)
-                     (forward-comment 1))
-                 (setf arg (+ arg inc)))
-            (signal (car err) (cdr err))))))
-      (setq arg (- arg inc)))))
 
 ;;;###autoload
 (defun rust-dbg-wrap-or-unwrap ()


### PR DESCRIPTION
Emacs-24 is now two major versions behind and will soon be three, so
formally remove support for it.

