### PR TITLE
Add missing ‘require’ form.

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -3,6 +3,7 @@
 (require 'rust-mode)
 (require 'ert)
 (require 'cl-lib)
+(require 'compile)
 (require 'imenu)
 
 (defconst rust-test-fill-column 32)


### PR DESCRIPTION
‘compilation-face’ is defined in the ‘compile’ library, so we should ‘require’
that library.