### PR TITLE
Make more easily comparable with rustic fork

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -137,7 +137,7 @@ to the function arguments.  When nil, `->' will be indented one level."
   "Face for interpolating braces in builtin formatting macro strings."
   :group 'rust-mode)
 
-;;; Rust-mode
+;;; Syntax
 
 (defun rust-re-word (inner) (concat "\\<" inner "\\>"))
 (defun rust-re-grab (inner) (concat "\\(" inner "\\)"))
@@ -229,6 +229,8 @@ Use idomenu (imenu with `ido-mode') for best mileage.")
 
     table)
   "Syntax definitions and helpers.")
+
+;;; Mode
 
 (defvar rust-mode-map
   (let ((map (make-sparse-keymap)))
@@ -934,7 +936,8 @@ buffer."
   (save-excursion (= (progn (goto-char pos1) (line-end-position))
                      (progn (goto-char pos2) (line-end-position)))))
 
-;; Font-locking definitions and helpers
+;;; Font-locking definitions and helpers
+
 (defun rust-next-string-interpolation (limit)
   "Search forward from point for next Rust interpolation marker before LIMIT.
 Set point to the end of the occurrence found, and return match beginning
@@ -1372,6 +1375,8 @@ whichever comes first."
         (put-text-property (1- (match-end 2)) (match-end 2)
                            'syntax-table (string-to-syntax "|"))
         (goto-char (match-end 0))))))
+
+;;; Syntax Propertize
 
 (defun rust-syntax-propertize (start end)
   "A `syntax-propertize-function' to apply properties from START to END."
@@ -1911,6 +1916,8 @@ Return the created process."
   (interactive)
   (compile (format "%s test" rust-cargo-bin)))
 
+;;; Hooks
+
 (defun rust-before-save-hook ()
   (when rust-format-on-save
     (condition-case e
@@ -1928,6 +1935,8 @@ Return the created process."
         ;; would show "Wrote ..." instead of the error description.
         (or (rust--format-error-handler)
             (message "rustfmt detected problems, see *rustfmt* for more."))))))
+
+;;; Compilation
 
 (defvar rustc-compilation-location
   (let ((file "\\([^\n]+\\)")
@@ -1998,7 +2007,7 @@ the compilation window until the top of the error is visible."
      (add-to-list 'compilation-error-regexp-alist 'cargo)
      (add-hook 'next-error-hook 'rustc-scroll-down-after-next-error)))
 
-;;; Functions to submit (parts of) buffers to the rust playpen, for sharing.
+;;; Secondary Commands
 
 (defun rust-playpen-region (begin end)
   "Create a shareable URL for the region from BEGIN to END on the Rust playpen."
@@ -2065,6 +2074,8 @@ visit the new file."
          (compile-command (mapconcat #'shell-quote-argument args " ")))
     (compile compile-command)))
 
+;;; Utilities
+
 (defun rust-update-buffer-project ()
   (setq-local rust-buffer-project (rust-buffer-project)))
 
@@ -2077,6 +2088,8 @@ visit the new file."
       (goto-char 0)
       (let ((output (json-read)))
         (cdr (assoc-string "root" output))))))
+
+;;; Secondary Commands
 
 (defun rust-insert-dbg ()
   "Insert the dbg! macro."
@@ -2118,6 +2131,8 @@ visit the new file."
                (delete-char -4)
                (delete-pair))
               (t (rust-insert-dbg)))))))
+
+;;; _
 
 (defun rust-mode-reload ()
   (interactive)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -77,7 +77,8 @@
           (regexp-opt
            '("enum" "struct" "union" "type" "mod" "use" "fn" "static" "impl"
              "extern" "trait"))
-          "\\_>"))
+          "\\_>")
+  "Start of a Rust item.")
 
 (defun rust-looking-back-str (str)
   "Return non-nil if there's a match on the text before point and STR.
@@ -141,7 +142,8 @@ seen as a macro."
     (modify-syntax-entry ?\n "> b"    table)
     (modify-syntax-entry ?\^m "> b"   table)
 
-    table))
+    table)
+  "Syntax definitions and helpers.")
 
 (defgroup rust-mode nil
   "Support for Rust code."
@@ -185,7 +187,7 @@ to the function arguments.  When nil, `->' will be indented one level."
   :group 'rust-mode)
 
 (defcustom rust-match-angle-brackets t
-  "Whether to attempt angle bracket matching (`<' and `>') where appropriate."
+  "Whether to enable angle bracket (`<' and `>') matching where appropriate."
   :type 'boolean
   :safe #'booleanp
   :group 'rust-mode)
@@ -686,7 +688,8 @@ buffer."
     "use"
     "virtual"
     "where" "while"
-    "yield"))
+    "yield")
+  "Font-locking definitions and helpers.")
 
 (defconst rust-special-types
   '("u8" "i8"
@@ -744,7 +747,7 @@ Does not match type annotations of the form \"foo::<\"."
              (throw 'rust-path-font-lock-matcher match))))))))
 
 (defun rust-next-string-interpolation (limit)
-  "Search forward from point for the next Rust interpolation marker before LIMIT.
+  "Search forward from point for next Rust interpolation marker before LIMIT.
 Set point to the end of the occurrence found, and return match beginning
 and end."
   (catch 'match
@@ -765,8 +768,8 @@ and end."
                 (throw 'match (list start (point)))))))))))
 
 (defun rust-string-interpolation-matcher (limit)
-  "Match the next Rust interpolation marker before LIMIT; set match data if found.
-Returns nil if the point is not within a Rust string."
+  "Match next Rust interpolation marker before LIMIT and set match data if found.
+Returns nil if not within a Rust string."
   (when (rust-in-str)
     (let ((match (rust-next-string-interpolation limit)))
       (when match
@@ -782,7 +785,7 @@ Returns nil if the point is not within a Rust string."
     "println")
   "List of builtin Rust macros for string formatting.
 This is used by `rust-font-lock-keywords'.
-(`write!' is handled separately).")
+\(`write!' is handled separately).")
 
 (defvar rust-formatting-macro-opening-re
   "[[:space:]\n]*[({[][[:space:]\n]*"
@@ -916,7 +919,6 @@ I.e. if we are before an ident that is part of a declaration that
 can have a where clause, rewind back to just before the name of
 the subject of that where clause and return the new point.
 Otherwise return nil."
-
   (let* ((ident-pos (point))
          (newpos (save-excursion
                    (rust-rewind-irrelevant)
@@ -1134,9 +1136,8 @@ outside of this context."
        ((looking-back rust-re-pre-expression-operators (1- (point))) t)))))
 
 (defun rust-is-lt-char-operator ()
-  "Return t if the `<' after the point is the less-than operator.
-Otherwise, for instance if it's an opening angle bracket, return nil."
-
+  "Return non-nil if the `<' sign just after point is an operator.
+Otherwise, if it is an opening angle bracket, then return nil."
   (let ((case-fold-search nil))
     (save-excursion
       (rust-rewind-irrelevant)
@@ -1239,7 +1240,7 @@ should be considered a paired angle bracket."
       (/= (following-char) ?<)))))
 
 (defun rust-mode-syntactic-face-function (state)
-  "Return face which distinguishes doc and normal comments in the given syntax STATE."
+  "Return face that distinguishes doc and normal comments in given syntax STATE."
   (if (nth 3 state)
       'font-lock-string-face
     (save-excursion

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -409,8 +409,8 @@ Does not match type annotations of the form \"foo::<\"."
      (,(concat (rust-re-grab
                 (concat (rust-re-word (regexp-opt rust-builtin-formatting-macros))
                         "!"))
-               (concat rust-formatting-macro-opening-re
-                       "\\(?:" rust-start-of-string-re) "\\)?")
+               rust-formatting-macro-opening-re
+               "\\(?:" rust-start-of-string-re "\\)?")
       (1 'rust-builtin-formatting-macro-face)
       (rust-string-interpolation-matcher
        (rust-end-of-string)
@@ -419,8 +419,9 @@ Does not match type annotations of the form \"foo::<\"."
 
      ;; write! macro
      (,(concat (rust-re-grab (concat (rust-re-word "write\\(ln\\)?") "!"))
-               (concat rust-formatting-macro-opening-re
-                       "[[:space:]]*[^\"]+,[[:space:]]*" rust-start-of-string-re))
+               rust-formatting-macro-opening-re
+               "[[:space:]]*[^\"]+,[[:space:]]*"
+               rust-start-of-string-re)
       (1 'rust-builtin-formatting-macro-face)
       (rust-string-interpolation-matcher
        (rust-end-of-string)
@@ -440,7 +441,9 @@ Does not match type annotations of the form \"foo::<\"."
 
      ;; Type-inferred binding
      (,(concat "\\_<\\(?:let\\s-+ref\\|let\\|ref\\|for\\)\\s-+\\(?:mut\\s-+\\)?"
-               (rust-re-grab rust-re-ident) "\\_>") 1 font-lock-variable-name-face)
+               (rust-re-grab rust-re-ident)
+               "\\_>")
+      1 font-lock-variable-name-face)
 
      ;; Type names like `Foo::`, highlight excluding the ::
      (,(rust-path-font-lock-matcher rust-re-uc-ident) 1 font-lock-type-face)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -28,6 +28,115 @@
 (defvar rust-buffer-project nil)
 (make-variable-buffer-local 'rust-buffer-project)
 
+;;; Customization
+
+(defgroup rust-mode nil
+  "Support for Rust code."
+  :link '(url-link "https://www.rust-lang.org/")
+  :group 'languages)
+
+(defcustom rust-indent-offset 4
+  "Indent Rust code by this number of spaces."
+  :type 'integer
+  :group 'rust-mode
+  :safe #'integerp)
+
+(defcustom rust-indent-method-chain nil
+  "Indent Rust method chains, aligned by the `.' operators."
+  :type 'boolean
+  :group 'rust-mode
+  :safe #'booleanp)
+
+(defcustom rust-indent-where-clause nil
+  "Indent lines starting with the `where' keyword following a function or trait.
+When nil, `where' will be aligned with `fn' or `trait'."
+  :type 'boolean
+  :group 'rust-mode
+  :safe #'booleanp)
+
+(defcustom rust-playpen-url-format "https://play.rust-lang.org/?code=%s"
+  "Format string to use when submitting code to the playpen."
+  :type 'string
+  :group 'rust-mode)
+
+(defcustom rust-shortener-url-format "https://is.gd/create.php?format=simple&url=%s"
+  "Format string to use for creating the shortened link of a playpen submission."
+  :type 'string
+  :group 'rust-mode)
+
+(defcustom rust-match-angle-brackets t
+  "Whether to enable angle bracket (`<' and `>') matching where appropriate."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'rust-mode)
+
+(defcustom rust-format-on-save nil
+  "Format future rust buffers before saving using rustfmt."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'rust-mode)
+
+(defcustom rust-format-show-buffer t
+  "Show *rustfmt* buffer if formatting detected problems."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'rust-mode)
+
+(defcustom rust-format-goto-problem t
+  "Jump to location of first detected problem when formatting buffer."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'rust-mode)
+
+(defcustom rust-rustfmt-bin "rustfmt"
+  "Path to rustfmt executable."
+  :type 'string
+  :group 'rust-mode)
+
+(defcustom rust-rustfmt-switches '("--edition" "2018")
+  "Arguments to pass when invoking the `rustfmt' executable."
+  :type '(repeat string)
+  :group 'rust-mode)
+
+(defcustom rust-cargo-bin "cargo"
+  "Path to cargo executable."
+  :type 'string
+  :group 'rust-mode)
+
+(defcustom rust-always-locate-project-on-open nil
+  "Whether to run `cargo locate-project' every time `rust-mode' is activated."
+  :type 'boolean
+  :group 'rust-mode)
+
+(defcustom rust-indent-return-type-to-arguments t
+  "Indent a line starting with the `->' (RArrow) following a function, aligning
+to the function arguments.  When nil, `->' will be indented one level."
+  :type 'boolean
+  :group 'rust-mode
+  :safe #'booleanp)
+
+;;; Faces
+
+(defface rust-unsafe-face
+  '((t :inherit font-lock-warning-face))
+  "Face for the `unsafe' keyword."
+  :group 'rust-mode)
+
+(defface rust-question-mark-face
+  '((t :weight bold :inherit font-lock-builtin-face))
+  "Face for the question mark operator."
+  :group 'rust-mode)
+
+(defface rust-builtin-formatting-macro-face
+  '((t :inherit font-lock-builtin-face))
+  "Face for builtin formatting macros (print! &c.)."
+  :group 'rust-mode)
+
+(defface rust-string-interpolation-face
+  '((t :slant italic :inherit font-lock-string-face))
+  "Face for interpolating braces in builtin formatting macro strings."
+  :group 'rust-mode)
+
 (defun rust-re-word (inner) (concat "\\<" inner "\\>"))
 (defun rust-re-grab (inner) (concat "\\(" inner "\\)"))
 (defun rust-re-shy (inner) (concat "\\(?:" inner "\\)"))
@@ -144,111 +253,6 @@ seen as a macro."
 
     table)
   "Syntax definitions and helpers.")
-
-(defgroup rust-mode nil
-  "Support for Rust code."
-  :link '(url-link "https://www.rust-lang.org/")
-  :group 'languages)
-
-(defcustom rust-indent-offset 4
-  "Indent Rust code by this number of spaces."
-  :type 'integer
-  :group 'rust-mode
-  :safe #'integerp)
-
-(defcustom rust-indent-method-chain nil
-  "Indent Rust method chains, aligned by the `.' operators."
-  :type 'boolean
-  :group 'rust-mode
-  :safe #'booleanp)
-
-(defcustom rust-indent-where-clause nil
-  "Indent lines starting with the `where' keyword following a function or trait.
-When nil, `where' will be aligned with `fn' or `trait'."
-  :type 'boolean
-  :group 'rust-mode
-  :safe #'booleanp)
-
-(defcustom rust-indent-return-type-to-arguments t
-  "Indent a line starting with the `->' (RArrow) following a function, aligning
-to the function arguments.  When nil, `->' will be indented one level."
-  :type 'boolean
-  :group 'rust-mode
-  :safe #'booleanp)
-
-(defcustom rust-playpen-url-format "https://play.rust-lang.org/?code=%s"
-  "Format string to use when submitting code to the playpen."
-  :type 'string
-  :group 'rust-mode)
-
-(defcustom rust-shortener-url-format "https://is.gd/create.php?format=simple&url=%s"
-  "Format string to use for creating the shortened link of a playpen submission."
-  :type 'string
-  :group 'rust-mode)
-
-(defcustom rust-match-angle-brackets t
-  "Whether to enable angle bracket (`<' and `>') matching where appropriate."
-  :type 'boolean
-  :safe #'booleanp
-  :group 'rust-mode)
-
-(defcustom rust-format-on-save nil
-  "Format future rust buffers before saving using rustfmt."
-  :type 'boolean
-  :safe #'booleanp
-  :group 'rust-mode)
-
-(defcustom rust-format-show-buffer t
-  "Show *rustfmt* buffer if formatting detected problems."
-  :type 'boolean
-  :safe #'booleanp
-  :group 'rust-mode)
-
-(defcustom rust-format-goto-problem t
-  "Jump to location of first detected problem when formatting buffer."
-  :type 'boolean
-  :safe #'booleanp
-  :group 'rust-mode)
-
-(defcustom rust-rustfmt-bin "rustfmt"
-  "Path to rustfmt executable."
-  :type 'string
-  :group 'rust-mode)
-
-(defcustom rust-rustfmt-switches '("--edition" "2018")
-  "Arguments to pass when invoking the `rustfmt' executable."
-  :type '(repeat string)
-  :group 'rust-mode)
-
-(defcustom rust-cargo-bin "cargo"
-  "Path to cargo executable."
-  :type 'string
-  :group 'rust-mode)
-
-(defcustom rust-always-locate-project-on-open nil
-  "Whether to run `cargo locate-project' every time `rust-mode' is activated."
-  :type 'boolean
-  :group 'rust-mode)
-
-(defface rust-unsafe-face
-  '((t :inherit font-lock-warning-face))
-  "Face for the `unsafe' keyword."
-  :group 'rust-mode)
-
-(defface rust-question-mark-face
-  '((t :weight bold :inherit font-lock-builtin-face))
-  "Face for the question mark operator."
-  :group 'rust-mode)
-
-(defface rust-builtin-formatting-macro-face
-  '((t :inherit font-lock-builtin-face))
-  "Face for builtin formatting macros (print! &c.)."
-  :group 'rust-mode)
-
-(defface rust-string-interpolation-face
-  '((t :slant italic :inherit font-lock-string-face))
-  "Face for interpolating braces in builtin formatting macro strings."
-  :group 'rust-mode)
 
 (defun rust-paren-level () (nth 0 (syntax-ppss)))
 (defun rust-in-str () (nth 3 (syntax-ppss)))


### PR DESCRIPTION
A few months ago it looked like I was going to learn Rust and so I looked for the best Emacs major-mode.  (Actually learning Rust got delayed, but I still plan on doing it.) I found this `rust-mode` and the `rustic` fork by @brotzeit.

I think that fork was a bit unfortunate.  What @brotzeit mostly did was to add extra functionality but he also refactored the existing essential major-mode/syntax/... parts.  Many of these changes were rather superficial, but because I did not backport them immediately *and* made major rearrangements it became very hard to compare the respective bits from the two implementations.

These commits, which I wrote five months ago for the most part, try to fix that.  I already got a lot of cleanup merged into `rustic` before, what these commits here to is to arrange `rust-mode.el` the same way `rustic.el` has been rearranged before. Other commits port doc-string improvements, other cleanup and the addition of `outline-minor-mode`-compatible section headings.

After applying these changes you can copy `rustic.el` from the other repository, rename it to `rust-mode.el` and also do `s/rustic/rust` inside and then you get pretty useful diff. (I do not think that *all* rearrangement is an improvement or even just necessary. Some are, but others don't really make a difference either way.)

My hope is that I can get you guys to cooperate some more, so that eventually there won't be two major-modes anymore. I think it makes sense for there two be two projects, a battery-included thing like `rustic` and a just-the-major-mode `rust-mode`, but it would be great if `rust` could just use the `rust-mode.el` from `rust-mode`.

I have written these commits and a lot of cleanup to `rustic` that has already been merged, but I think that from here you will have to pick it up and make the fork a thing of the past.

Thanks for considering this proposal,
and lots of fun with the commits!