### PR TITLE
Add let-binding for json-object-type around json-read call 

### DIFF
--- a/rust-cargo.el
+++ b/rust-cargo.el
@@ -46,7 +46,8 @@
         (when (/= ret 0)
           (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
         (goto-char 0)
-        (let ((output (json-read)))
+        (let ((output (let ((json-object-type 'alist))
+                        (json-read))))
           (cdr (assoc-string "root" output)))))))
 
 (defun rust-buffer-crate ()


### PR DESCRIPTION
Current version of rust-buffer-project can fail if somewhere json-object-type settled to hash-table.

This MR add let*-binding for use json-object-type with alist type.