### PR TITLE
Add rust-check function

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1910,6 +1910,11 @@ Return the created process."
               default-directory)))
     (compile (apply #'format format-string args))))
 
+(defun rust-check ()
+  "Compile using `cargo check`"
+  (interactive)
+  (rust--compile "%s check" rust-cargo-bin))
+
 (defun rust-compile ()
   "Compile using `cargo build`"
   (interactive)


### PR DESCRIPTION
Because check exists and is so much faster, I only ever want to build
when I want to test the binary, in which case I'd use run.  So I think
it's more useful to have a rust-check function available than it is to
even have rust-compile.