### PR TITLE
Add convenience functions for build/run in release mode

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -1920,10 +1920,20 @@ Return the created process."
   (interactive)
   (rust--compile "%s build" rust-cargo-bin))
 
+(defun rust-compile-release ()
+  "Compile using `cargo build --release`"
+  (interactive)
+  (rust--compile "%s build --release" rust-cargo-bin))
+
 (defun rust-run ()
   "Run using `cargo run`"
   (interactive)
   (rust--compile "%s run" rust-cargo-bin))
+
+(defun rust-run-release ()
+  "Run using `cargo run --release`"
+  (interactive)
+  (rust--compile "%s run --release" rust-cargo-bin))
 
 (defun rust-test ()
   "Test using `cargo test`"


### PR DESCRIPTION
Added functions for both building and running with the `--release` option, for convenience purposes.