### PR TITLE
Improve rust--format-fix-rustfmt-buffer

### DIFF
--- a/rust-rustfmt.el
+++ b/rust-rustfmt.el
@@ -75,12 +75,14 @@
               (erase-buffer)
               (insert-file-contents tmpf)
               (rust--format-fix-rustfmt-buffer (buffer-name buf))
-              (error "Rustfmt could not format some lines, see *rustfmt* buffer for details"))
+              (error "Rustfmt could not format some lines, see %s buffer for details"
+                     rust-rustfmt-buffername))
              (t
               (erase-buffer)
               (insert-file-contents tmpf)
               (rust--format-fix-rustfmt-buffer (buffer-name buf))
-              (error "Rustfmt failed, see *rustfmt* buffer for details"))))
+              (error "Rustfmt failed, see %s buffer for details"
+                     rust-rustfmt-buffername))))
         (delete-file tmpf)))))
 
 ;; Since we run rustfmt through stdin we get <stdin> markers in the
@@ -118,7 +120,7 @@ rustfmt complain in the echo area."
   ;; buffer it is from.
   (let ((rustfmt (get-buffer rust-rustfmt-buffername)))
     (if (not rustfmt)
-        (message "No *rustfmt*, no problems.")
+        (message "No %s, no problems." rust-rustfmt-buffername)
       (let ((target-buffer (with-current-buffer rustfmt
                              (save-excursion
                                (goto-char (point-min))
@@ -361,7 +363,8 @@ Return the created process."
         ;; KLDUGE: re-run the error handlers -- otherwise message area
         ;; would show "Wrote ..." instead of the error description.
         (or (rust--format-error-handler)
-            (message "rustfmt detected problems, see *rustfmt* for more."))))))
+            (message "rustfmt detected problems, see %s for more."
+                     rust-rustfmt-buffername))))))
 
 ;;; _
 (provide 'rust-rustfmt)

--- a/rust-rustfmt.el
+++ b/rust-rustfmt.el
@@ -86,13 +86,13 @@
 ;; Since we run rustfmt through stdin we get <stdin> markers in the
 ;; output. This replaces them with the buffer name instead.
 (defun rust--format-fix-rustfmt-buffer (buffer-name)
-  (with-current-buffer (get-buffer rust-rustfmt-buffername)
-    (let ((inhibit-read-only t))
-      (goto-char (point-min))
-      (while (re-search-forward "--> <stdin>:" nil t)
-        (replace-match (format "--> %s:" buffer-name)))
-      (while (re-search-forward "--> stdin:" nil t)
-        (replace-match (format "--> %s:" buffer-name))))))
+  (save-match-data
+    (with-current-buffer (get-buffer rust-rustfmt-buffername)
+      (let ((inhibit-read-only t)
+            (fixed (format "--> %s:" buffer-name)))
+          (goto-char (point-min))
+          (while (re-search-forward "--> \\(?:<stdin>\\|stdin\\):" nil t)
+            (replace-match fixed))))))
 
 ;; If rust-mode has been configured to navigate to source of the error
 ;; or display it, do so -- and return true. Otherwise return nil to


### PR DESCRIPTION
I noticed that two loops can be merged into one. Also `save-match-data` will make this function not clobber global match data (not that anyone was suffering from that but nonetheless).

Upd: also noticed that `*rustfmt*` name can be configured but in error messages it'll stay the same. Fixed that too.