### PR TITLE
Fix cargo compilation regex

### DIFF
--- a/rust-compile.el
+++ b/rust-compile.el
@@ -37,8 +37,8 @@ See `compilation-error-regexp-alist' for help on their format.")
 ;; Match test run failures and panics during compilation as
 ;; compilation warnings
 (defvar cargo-compilation-regexps
-  '("', \\([^:]+\\):\\([0-9]+\\)"
-    1 2 nil nil 0)
+  '("', \\(\\([^:]+\\):\\([0-9]+\\)\\)"
+    2 3 nil nil 1)
   "Specifications for matching panics in cargo test invocations.
 See `compilation-error-regexp-alist' for help on their format.")
 

--- a/rust-compile.el
+++ b/rust-compile.el
@@ -37,8 +37,8 @@ See `compilation-error-regexp-alist' for help on their format.")
 ;; Match test run failures and panics during compilation as
 ;; compilation warnings
 (defvar cargo-compilation-regexps
-  '("^\\s-+thread '[^']+' panicked at \\('[^']+', \\([^:]+\\):\\([0-9]+\\)\\)"
-    2 3 nil nil 1)
+  '("', \\([^:]+\\):\\([0-9]+\\)"
+    1 2 nil nil 0)
   "Specifications for matching panics in cargo test invocations.
 See `compilation-error-regexp-alist' for help on their format.")
 


### PR DESCRIPTION
Currently the regex that matches panic messages in cargo output does not correctly match the file name and line number. This causes attempts to jump to one of these failures with `next-error` (or similar commands) brings up a prompt for a file name to search in and generally causes unnecessary friction in dealing with test failures or other explicit panics during tests.

This change to the regex provides at least a partial fix for that issue by reducing the amount of text matched so that it won't be a multi-line match. The new method has a small chance of false-positive matches, but a really robust method would require substantially more code I think. I might work on that too though because I think I have an idea of how that might work.

The second commit reduces the amount of text that would be highlighted/underlined by compilation mode when that regex does match. This version only underlines the filename and line number rather than the entire panic message.

