### PR TITLE
Highlight funcalls

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -389,7 +389,7 @@ r\"foo\\\", \"bar\", r\"bar\";
 r\"foo\\.\", \"bar\", r\"bar\";
 r\"foo\\..\", \"bar\", r\"foo\\..\\bar\";
 r\"\\\", \"foo\", r\"\\foo\";
-not_a_string();
+not_a_string;
 
 "
 
@@ -1579,12 +1579,12 @@ list of substrings of `STR' each followed by its face."
 
 (ert-deftest font-lock-raw-string-with-inner-hash ()
   (rust-test-font-lock
-   "r##\"I've got an octothorpe (#)\"##; foo()"
+   "r##\"I've got an octothorpe (#)\"##; foo"
    '("r##\"I've got an octothorpe (#)\"##" font-lock-string-face)))
 
 (ert-deftest font-lock-raw-string-with-inner-quote-and-hash ()
   (rust-test-font-lock
-   "not_the_string(); r##\"string \"# still same string\"##; not_the_string()"
+   "not_the_string; r##\"string \"# still same string\"##; not_the_string"
    '("r##\"string \"# still same string\"##" font-lock-string-face)))
 
 (ert-deftest font-lock-string-ending-with-r-not-raw-string ()
@@ -1620,7 +1620,7 @@ fn g() {
 (ert-deftest font-lock-raw-string-trick-ending-followed-by-string-with-quote ()
   (rust-test-font-lock
    "r\"With what looks like the start of a raw string at the end r#\";
-not_a_string();
+not_a_string;
 r##\"With \"embedded\" quote \"##;"
    '("r\"With what looks like the start of a raw string at the end r#\"" font-lock-string-face
      "r##\"With \"embedded\" quote \"##" font-lock-string-face)))
@@ -1629,7 +1629,7 @@ r##\"With \"embedded\" quote \"##;"
   ;; Check that it won't look for a raw string beginning inside another raw string.
   (rust-test-font-lock
    "r#\"In the first string r\" in the first string \"#;
-not_in_a_string();
+not_in_a_string;
 r##\"In the second string\"##;"
    '("r#\"In the first string r\" in the first string \"#" font-lock-string-face
      "r##\"In the second string\"##" font-lock-string-face)))
@@ -1639,7 +1639,7 @@ r##\"In the second string\"##;"
   (rust-test-font-lock
    "// r\" this is a comment
 \"this is a string\";
-this_is_not_a_string();)"
+this_is_not_a_string;)"
    '("// " font-lock-comment-delimiter-face
      "r\" this is a comment\n" font-lock-comment-face
      "\"this is a string\"" font-lock-string-face)))
@@ -1790,16 +1790,16 @@ this_is_not_a_string();)"
    '("?" rust-question-mark))
   (rust-test-font-lock
    "foo\(\)?;"
-   '("?" rust-question-mark))
+   '("foo" font-lock-function-name-face "?" rust-question-mark))
   (rust-test-font-lock
    "foo\(bar\(\)?\);"
-   '("?" rust-question-mark))
+   '("foo" font-lock-function-name-face "bar" font-lock-function-name-face "?" rust-question-mark))
   (rust-test-font-lock
    "\"?\""
    '("\"?\"" font-lock-string-face))
   (rust-test-font-lock
    "foo\(\"?\"\);"
-   '("\"?\"" font-lock-string-face))
+   '("foo" font-lock-function-name-face "\"?\"" font-lock-string-face))
   (rust-test-font-lock
    "// ?"
    '("// " font-lock-comment-delimiter-face
@@ -1809,10 +1809,11 @@ this_is_not_a_string();)"
    '("/// ?" font-lock-doc-face))
   (rust-test-font-lock
    "foo\(\"?\"\);"
-   '("\"?\"" font-lock-string-face))
+   '("foo" font-lock-function-name-face "\"?\"" font-lock-string-face))
   (rust-test-font-lock
    "foo\(\"?\"\)?;"
-   '("\"?\"" font-lock-string-face
+   '("foo" font-lock-function-name-face
+     "\"?\"" font-lock-string-face
      "?" rust-question-mark)))
 
 (ert-deftest rust-test-default-context-sensitive ()

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -131,6 +131,10 @@ to the function arguments.  When nil, `->' will be indented one level."
 (defconst rust-re-ident "[[:word:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*")
 (defconst rust-re-lc-ident "[[:lower:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*")
 (defconst rust-re-uc-ident "[[:upper:]][[:word:][:multibyte:]_[:digit:]]*")
+
+(defvar rust-re-funcall
+  (concat (rust-re-grab rust-re-ident) "[[:space:]\n]*("))
+
 (defvar rust-re-vis
   ;; pub | pub ( crate ) | pub ( self ) | pub ( super ) | pub ( in SimplePath )
   (concat
@@ -487,6 +491,9 @@ Does not match type annotations of the form \"foo::<\"."
       1 'rust-ampersand-face)
      ;; Numbers with type suffix
      (,rust-number-with-type 1 font-lock-type-face)
+
+     ;; Function calls
+     (,rust-re-funcall 1 'font-lock-function-name-face)
      )
 
    ;; Ensure we highlight `Foo` in `struct Foo` as a type.


### PR DESCRIPTION
One feature I quite like of Emacs's [go-mode](https://github.com/dominikh/go-mode.el) is how it highlights function calls. I use a theme that has very few colors, and highlighting the calls helps to guide my eyes. I replicated the feature for rust-mode. Here's a screenshot.

![image](https://user-images.githubusercontent.com/39868/145727902-6585cde7-ef93-40e1-b51a-b2d68757f184.png)
