### PR TITLE
Add a face for the ampersand reference mark

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1699,6 +1699,7 @@ this_is_not_a_string();)"
      "foo" font-lock-type-face
      "x" font-lock-variable-name-face
      ;; This union is the name of a lifetime.
+     "&" rust-ampersand-face
      "union" font-lock-variable-name-face
      "bar" font-lock-type-face)))
 

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -101,6 +101,11 @@ to the function arguments.  When nil, `->' will be indented one level."
   "Face for the question mark operator."
   :group 'rust-mode)
 
+(defface rust-ampersand-face
+  '((t :inherit default))
+  "Face for the ampersand reference mark."
+  :group 'rust-mode)
+
 (defface rust-builtin-formatting-macro
   '((t :inherit font-lock-builtin-face))
   "Face for builtin formatting macros (print! &c.)."
@@ -437,6 +442,7 @@ Does not match type annotations of the form \"foo::<\"."
 
      ;; Question mark operator
      ("\\?" . 'rust-question-mark)
+     ("\\(&\\)'?\\<" 1 'rust-ampersand-face)
      )
 
    ;; Ensure we highlight `Foo` in `struct Foo` as a type.


### PR DESCRIPTION
Customizing this face may improve code readability for some users.
By default nothing is set for the face for backward compatibility.