### PR TITLE
Enable the use of prettify-symbols-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ on save:
 (setq rust-format-on-save t)
 ```
 
+### Prettifying
+
+You can toggle prettification of your code by running `M-x
+prettify-symbols-mode`.  If you'd like to automatically enable this
+for all rust files, add the following to your init.el.
+
+```elisp
+(add-hook 'rust-mode-hook
+          (lambda () (prettify-symbols-mode)))
+```
+
+You can add your own prettifications to `rust-prettify-symbols-alist`.
+For example, to display `x.add(y)` as `x∔(y)`, simply add to your init
+file `(push '(".add" . ?∔) rust-prettify-symbols-alist)`.
+
 ### Running / testing / compiling code
 
 The `rust-run`, `rust-test`, `rust-compile` and `rust-check` functions

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -41,6 +41,12 @@ This variable might soon be remove again.")
   :type 'function
   :group 'rust-mode)
 
+(defvar rust-prettify-symbols-alist
+  '(("&&" . ?∧) ("||" . ?∨)
+    ("<=" . ?≤)  (">=" . ?≥) ("!=" . ?≠)
+    ("INFINITY" . ?∞) ("->" . ?→) ("=>" . ?⇒))
+  "Alist of symbol prettifications used for `prettify-symbols-alist'.")
+
 ;;; Customization
 
 (defgroup rust-mode nil
@@ -204,6 +210,20 @@ Use idomenu (imenu with `ido-mode') for best mileage.")
     table)
   "Syntax definitions and helpers.")
 
+;;; Prettify
+
+(defun rust--prettify-symbols-compose-p (start end match)
+  "Return true iff the symbol MATCH should be composed.
+See `prettify-symbols-compose-predicate'."
+  (and (fboundp 'prettify-symbols-default-compose-p)
+       (prettify-symbols-default-compose-p start end match)
+       ;; Make sure there is a space before || as it is also used for
+       ;; functions with 0 arguments.
+       (not (and (string= match "||")
+                 (save-excursion
+                   (goto-char start)
+                   (looking-back "\\(?:\\<move\\|=\\) *"))))))
+
 ;;; Mode
 
 (defvar rust-mode-map
@@ -273,6 +293,9 @@ Use idomenu (imenu with `ido-mode') for best mileage.")
   (setq-local electric-pair-inhibit-predicate
               'rust-electric-pair-inhibit-predicate-wrap)
   (setq-local electric-pair-skip-self 'rust-electric-pair-skip-self-wrap)
+  ;; Configure prettify
+  (setq prettify-symbols-alist rust-prettify-symbols-alist)
+  (setq prettify-symbols-compose-predicate #'rust--prettify-symbols-compose-p)
 
   (add-hook 'before-save-hook rust-before-save-hook nil t)
   (add-hook 'after-save-hook rust-after-save-hook nil t))


### PR DESCRIPTION
Make `M-x prettify-symbols-mode` prettify some symbols (e.g. `<=`, `>=`, `->`) in Rust code.