### PR TITLE
Improve and add tests for my previous 2 contributions

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1354,6 +1354,92 @@ list of substrings of `STR' each followed by its face."
      "mut" font-lock-keyword-face
      "bar" font-lock-variable-name-face)))
 
+(ert-deftest font-lock-ampersand ()
+  (rust-test-font-lock
+   "f(&a)"
+   '("&" rust-ampersand-face))
+  (rust-test-font-lock
+   "a && b &&& c"
+   nil)
+  (rust-test-font-lock
+   "&'a v"
+   '("&" rust-ampersand-face
+     "a" font-lock-variable-name-face))
+  (rust-test-font-lock
+   "&'static v"
+   '("&" rust-ampersand-face
+     "static" font-lock-keyword-face))
+  (rust-test-font-lock
+   "&mut v"
+   '("&" rust-ampersand-face
+     "mut" font-lock-keyword-face))
+  (rust-test-font-lock
+   "&f(&x)"
+   '("&" rust-ampersand-face
+     "&" rust-ampersand-face))
+  (rust-test-font-lock
+   "fn f(x: &X)"
+   '("fn" font-lock-keyword-face
+     "f" font-lock-function-name-face
+     "x" font-lock-variable-name-face
+     "&" rust-ampersand-face
+     "X" font-lock-type-face))
+  (rust-test-font-lock
+   "f(&X{x})"
+   '("&" rust-ampersand-face
+     "X" font-lock-type-face))
+  (rust-test-font-lock
+   "let x: &'_ f64 = &1.;"
+   '("let" font-lock-keyword-face
+     "x" font-lock-variable-name-face
+     "&" rust-ampersand-face
+     "_" font-lock-variable-name-face
+     "f64" font-lock-type-face
+     "&" rust-ampersand-face))
+  (rust-test-font-lock
+   "let x = &&1;"
+   '("let" font-lock-keyword-face
+     "x" font-lock-variable-name-face
+     "&&" rust-ampersand-face))
+  (rust-test-font-lock
+   "let x = &*y;"
+   '("let" font-lock-keyword-face
+     "x" font-lock-variable-name-face
+     "&" rust-ampersand-face))
+  (rust-test-font-lock
+   "let x = &::std::f64::consts::PI;"
+   '("let" font-lock-keyword-face
+     "x" font-lock-variable-name-face
+     "&" rust-ampersand-face
+     "std" font-lock-constant-face
+     "f64" font-lock-type-face
+     "consts" font-lock-constant-face
+     "PI" font-lock-type-face))
+  (rust-test-font-lock
+   "let x = &(1, 2);"
+   '("let" font-lock-keyword-face
+     "x" font-lock-variable-name-face
+     "&" rust-ampersand-face))
+  (rust-test-font-lock
+   "let x = &{1};"
+   '("let" font-lock-keyword-face
+     "x" font-lock-variable-name-face
+     "&" rust-ampersand-face))
+  (rust-test-font-lock
+   "let f = &|x| {x + 1};"
+   '("let" font-lock-keyword-face
+     "f" font-lock-variable-name-face
+     "&" rust-ampersand-face))
+  (rust-test-font-lock
+   "let x: &_ = &1;"
+   '("let" font-lock-keyword-face
+     "x" font-lock-variable-name-face
+     "&" rust-ampersand-face
+     "&" rust-ampersand-face))
+  (rust-test-font-lock
+   "&[1,2]"
+   '("&" rust-ampersand-face)))
+
 (ert-deftest font-lock-if-let-binding ()
   (rust-test-font-lock
    "if let Some(var) = some_var { /* no-op */ }"

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -467,7 +467,8 @@ Does not match type annotations of the form \"foo::<\"."
 
      ;; Question mark operator
      ("\\?" . 'rust-question-mark)
-     ("\\(&\\)'?\\<" 1 'rust-ampersand-face)
+     ("\\(&+\\)\\(?:'\\(?:\\<\\|_\\)\\|\\<\\|[[({:*_|]\\)"
+      1 'rust-ampersand-face)
      )
 
    ;; Ensure we highlight `Foo` in `struct Foo` as a type.

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -222,12 +222,14 @@ Use idomenu (imenu with `ido-mode') for best mileage.")
 See `prettify-symbols-compose-predicate'."
   (and (fboundp 'prettify-symbols-default-compose-p)
        (prettify-symbols-default-compose-p start end match)
-       ;; Make sure there is a space before || as it is also used for
-       ;; functions with 0 arguments.
-       (not (and (string= match "||")
-                 (save-excursion
-                   (goto-char start)
-                   (looking-back "\\(?:\\<move\\|=\\) *"))))))
+       ;; Make sure || is not a closure with 0 arguments and && is not
+       ;; a double reference.
+       (pcase match
+         ("||" (not (save-excursion
+                      (goto-char start)
+                      (looking-back "\\(?:\\<move\\|=\\) *"))))
+         ("&&" (char-equal (char-after end) ?\s))
+         (_ t))))
 
 ;;; Mode
 

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -227,7 +227,7 @@ See `prettify-symbols-compose-predicate'."
        (pcase match
          ("||" (not (save-excursion
                       (goto-char start)
-                      (looking-back "\\(?:\\<move\\|=\\) *"))))
+                      (looking-back "\\(?:\\<move\\|[[({:=,;]\\) *"))))
          ("&&" (char-equal (char-after end) ?\s))
          (_ t))))
 


### PR DESCRIPTION
This PR,
- is more careful when to prettify `&&` (disambiguation with a double reference) and `||` (distinguish from a closure with 0 args);
- improves the regexp to check that `&...&` is a reference;
- adds highlighting tests for `&`.