### PR TITLE
Add NonGNU ELPA badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # rust-mode
 
+[![NonGNU ELPA](https://elpa.nongnu.org/nongnu/rust-mode.svg)](https://elpa.nongnu.org/nongnu/rust-mode.html)
 [![MELPA](https://melpa.org/packages/rust-mode-badge.svg)](https://melpa.org/#/rust-mode)
 [![](https://github.com/rust-lang/rust-mode/workflows/CI/badge.svg)](https://github.com/rust-lang/rust-mode/actions?query=workflow%3ACI)
 


### PR DESCRIPTION
This adds a NonGNU ELPA badge to README.md.

You can see the badge here:
https://elpa.nongnu.org/nongnu/rust-mode.svg

Thanks!