### PR TITLE
Highlight the (optional) type suffix of numbers with the type face

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -1304,6 +1304,56 @@ list of substrings of `STR' each followed by its face."
    '("/* " font-lock-comment-delimiter-face
      "#[foo] */" font-lock-comment-face)))
 
+(ert-deftest font-lock-number-with-type ()
+  (rust-test-font-lock
+   "-123i32"
+   '("i32" font-lock-type-face))
+  (rust-test-font-lock
+   "123u32"
+   '("u32" font-lock-type-face))
+  (rust-test-font-lock
+   "123_123_u32"
+   '("u32" font-lock-type-face))
+  (rust-test-font-lock
+   "0xff_u8"
+   '("u8" font-lock-type-face))
+  (rust-test-font-lock
+   "0b1111_1111_1001_0000i64"
+   '("i64" font-lock-type-face))
+  (rust-test-font-lock
+   "0usize"
+   '("usize" font-lock-type-face))
+  (rust-test-font-lock
+   "123.0f64 + 1."
+   '("f64" font-lock-type-face))
+  (rust-test-font-lock
+   "0.1f32"
+   '("f32" font-lock-type-face))
+  (rust-test-font-lock
+   "12E+99_f64"
+   '("f64" font-lock-type-face))
+  (rust-test-font-lock
+   "5f32"
+   '("f32" font-lock-type-face))
+  (rust-test-font-lock
+   "0x5i32"
+   '("i32" font-lock-type-face))
+  (rust-test-font-lock
+   "1x5i32"
+   '())
+  (rust-test-font-lock
+   "0x5i321"
+   '())
+  (rust-test-font-lock
+   "fname5f32"
+   '())
+  (rust-test-font-lock
+   "0x5i32+1"
+   '("i32" font-lock-type-face))
+  (rust-test-font-lock
+   "f(0xFFi32)"
+   '("i32" font-lock-type-face)))
+
 (ert-deftest font-lock-double-quote-character-literal ()
   (rust-test-font-lock
    "'\"'; let"

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -361,6 +361,16 @@ See `prettify-symbols-compose-predicate'."
     "bool"
     "str" "char"))
 
+(defconst rust-number-with-type
+  (eval-when-compile
+    (concat
+     "\\_<\\(?:0[box]?\\|[1-9]\\)[[:digit:]a-fA-F_.]*\\(?:[eE][+-]?[[:digit:]_]\\)?"
+     (regexp-opt '("u8" "i8" "u16" "i16" "u32" "i32" "u64" "i64"
+                   "u128" "i128" "usize" "isize" "f32" "f64")
+                 t)
+     "\\_>"))
+  "Regular expression matching a number with a type suffix.")
+
 (defvar rust-builtin-formatting-macros
   '("eprint"
     "eprintln"
@@ -470,6 +480,8 @@ Does not match type annotations of the form \"foo::<\"."
      ("\\?" . 'rust-question-mark)
      ("\\(&+\\)\\(?:'\\(?:\\<\\|_\\)\\|\\<\\|[[({:*_|]\\)"
       1 'rust-ampersand-face)
+     ;; Numbers with type suffix
+     (,rust-number-with-type 1 font-lock-type-face)
      )
 
    ;; Ensure we highlight `Foo` in `struct Foo` as a type.


### PR DESCRIPTION
Highlight the type suffix in numbers: 

![f64](https://user-images.githubusercontent.com/1255665/152191319-6de2cedc-89f6-4052-80e5-1869f5f93d03.png)
