### PR TITLE
Use Eask for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,27 +4,33 @@ on: [push, pull_request]
 
 jobs:
     unix-test:
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
         strategy:
-            max-parallel: 6
+            fail-fast: false
             matrix:
+                os: [ubuntu-latest, macos-latest, windows-latest]
                 emacs-version:
                     - 26.3
                     - 27.2
+                    - 28.1
                     # - snapshot
 
         steps:
             - uses: actions/checkout@v2
 
-            - uses: purcell/setup-emacs@master
+            - uses: jcs090218/setup-emacs@master
               with:
                   version: ${{ matrix.emacs-version }}
 
-            - uses: conao3/setup-cask@master
+            - uses: actions/setup-node@v2
               with:
-                  version: 0.8.4
+                node-version: '16'
+
+            - uses: emacs-eask/setup-eask@master
+              with:
+                version: 'snapshot'
 
             - name: Run tests
               run: |
-                make test                  
+                make ci                  
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-    unix-test:
+    test:
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.elc
+*-autoloads.el
+
+.eask
+/dist

--- a/Eask
+++ b/Eask
@@ -1,0 +1,14 @@
+(package "rust-mode"
+         "1.0.4"
+         "A major-mode for editing Rust source code")
+
+(package-file "rust-mode.el")
+
+(files 
+ "rust-cargo.el"
+ "rust-compile.el"
+ "rust-playpen.el"
+ "rust-rustfmt.el"
+ "rust-utils.el")
+
+(depends-on "emacs" "25.1")

--- a/Eask
+++ b/Eask
@@ -12,3 +12,5 @@
  "rust-utils.el")
 
 (depends-on "emacs" "25.1")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LOAD_PATH  ?= $(addprefix -L ../,$(DEPS))
 LOAD_PATH  += -L .
 
 # TODO: add checkdoc and lint
-ci: build compile checkdoc
+ci: build compile test
 
 build:
 	$(EASK) package

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ DEPS  =
 LOAD_PATH  ?= $(addprefix -L ../,$(DEPS))
 LOAD_PATH  += -L .
 
-ci: build compile checkdoc lint test
+# TODO: add checkdoc and lint
+ci: build compile checkdoc
 
 build:
 	$(EASK) package


### PR DESCRIPTION
This patch does the following:

#### In `.github/workflow/test.yml`

* Use `jcs090218/setup-emacs` instead of `purcell/setup-emacs`
  - Add retry capability to prevent failure on Emacs' installation
  - Support windows
* Add setup-node (`16`)
* Remove `setup-cask` (replace with `setup-eask`)
* Add test for Emacs `28.1`
* Add tests on `Windows` and `macOS`

#### In `Makefile`

* Replace Emacs command-line arguments `emacs --batch ...` with just `eask <command>`
* Remove `ELS` variable, manage with `Eask`-file (use command `eask files` to list all package files)
* Add `make checkdoc` and `make lint` but currently disabled, see error log [here](https://github.com/jcs-PR/rust-mode/actions/runs/2235278555).
* Add `make build` to test packaging and installing.
* Replace `make xxx-autoloads` with just `eask autoloads`

#### Others

* `Eask`-file added

---

This is totally optional, I think this would make CI a lot easier.