### PR TITLE
Support envrc

### DIFF
--- a/rust-cargo.el
+++ b/rust-cargo.el
@@ -30,10 +30,17 @@
 
 (defun rust-buffer-project ()
   "Get project root if possible."
+  ;; Copy environment variables into the new buffer, since
+  ;; with-temp-buffer will re-use the variables' defaults, even if
+  ;; they have been changed in this variable using e.g. envrc-mode.
+  ;; See https://github.com/purcell/envrc/issues/12.
   (let ((env process-environment)
         (path exec-path))
     (with-temp-buffer
+      ;; Copy the entire environment just in case there's something we
+      ;; don't know we need.
       (setq-local process-environment env)
+      ;; Set PATH so we can find cargo.
       (setq-local exec-path path)
       (let ((ret (call-process rust-cargo-bin nil t nil "locate-project")))
         (when (/= ret 0)

--- a/rust-cargo.el
+++ b/rust-cargo.el
@@ -30,13 +30,17 @@
 
 (defun rust-buffer-project ()
   "Get project root if possible."
-  (with-temp-buffer
-    (let ((ret (call-process rust-cargo-bin nil t nil "locate-project")))
-      (when (/= ret 0)
-        (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
-      (goto-char 0)
-      (let ((output (json-read)))
-        (cdr (assoc-string "root" output))))))
+  (let ((env process-environment)
+        (path exec-path))
+    (with-temp-buffer
+      (setq-local process-environment env)
+      (setq-local exec-path path)
+      (let ((ret (call-process rust-cargo-bin nil t nil "locate-project")))
+        (when (/= ret 0)
+          (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
+        (goto-char 0)
+        (let ((output (json-read)))
+          (cdr (assoc-string "root" output)))))))
 
 (defun rust-update-buffer-project ()
   (setq-local rust-buffer-project (rust-buffer-project)))


### PR DESCRIPTION
Fixes #446.

I didn't see any tests for this code and wasn't exactly sure how to add one. However, I tested it by `eval`'ing the updated function in my `emacs` session and running `rust-test`. Before the change, it would error out, and after it successfully runs the tests.

It turns out setting `process-environment` wasn't enough for my situation so I set `exec-path` as well.
