### PR TITLE
Make compilation buffer workspace-aware

### DIFF
--- a/rust-cargo.el
+++ b/rust-cargo.el
@@ -30,26 +30,24 @@
 
 (defun rust-buffer-project ()
   "Get project root if possible."
-  (if (file-remote-p default-directory)
-      (rust-buffer-crate)
-    ;; Copy environment variables into the new buffer, since
-    ;; with-temp-buffer will re-use the variables' defaults, even if
-    ;; they have been changed in this variable using e.g. envrc-mode.
-    ;; See https://github.com/purcell/envrc/issues/12.
-    (let ((env process-environment)
-          (path exec-path))
-      (with-temp-buffer
-        ;; Copy the entire environment just in case there's something we
-        ;; don't know we need.
-        (setq-local process-environment env)
-        ;; Set PATH so we can find cargo.
-        (setq-local exec-path path)
-        (let ((ret (process-file rust-cargo-bin nil (list (current-buffer) nil) nil "locate-project" "--workspace")))
-          (when (/= ret 0)
-            (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
-          (goto-char 0)
-          (let ((output (json-read)))
-            (cdr (assoc-string "root" output))))))))
+  ;; Copy environment variables into the new buffer, since
+  ;; with-temp-buffer will re-use the variables' defaults, even if
+  ;; they have been changed in this variable using e.g. envrc-mode.
+  ;; See https://github.com/purcell/envrc/issues/12.
+  (let ((env process-environment)
+        (path exec-path))
+    (with-temp-buffer
+      ;; Copy the entire environment just in case there's something we
+      ;; don't know we need.
+      (setq-local process-environment env)
+      ;; Set PATH so we can find cargo.
+      (setq-local exec-path path)
+      (let ((ret (process-file rust-cargo-bin nil (list (current-buffer) nil) nil "locate-project" "--workspace")))
+        (when (/= ret 0)
+          (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
+        (goto-char 0)
+        (let ((output (json-read)))
+          (cdr (assoc-string "root" output)))))))
 
 (defun rust-buffer-crate ()
   "Try to locate Cargo.toml using `locate-dominating-file'."

--- a/rust-cargo.el
+++ b/rust-cargo.el
@@ -44,7 +44,7 @@
         (setq-local process-environment env)
         ;; Set PATH so we can find cargo.
         (setq-local exec-path path)
-        (let ((ret (call-process rust-cargo-bin nil t nil "locate-project")))
+        (let ((ret (process-file rust-cargo-bin nil (list (current-buffer) nil) nil "locate-project" "--workspace")))
           (when (/= ret 0)
             (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
           (goto-char 0)

--- a/test-project/Cargo.toml
+++ b/test-project/Cargo.toml
@@ -1,1 +1,10 @@
-# Dummy file needed for test
+# Dummy file needed for test.
+#
+# Needs to have at least a few fields set up, because
+#
+#   cargo locate-project --workspace
+#
+# will attempt to parse it and fail, if the file is empty.
+[package]
+name = "test-project"
+version = "0.1.0"

--- a/test-project/src/lib.rs
+++ b/test-project/src/lib.rs
@@ -1,0 +1,4 @@
+pub fn test_project() {
+    // This is only present, because cargo locate-project --workspace actually
+    // validates the rust project and fails if there is no target.
+}


### PR DESCRIPTION
This fixes incorrect paths for workspace projects when starting
compilation from a source file instead of the project root.

Fixes: https://github.com/rust-lang/rust-mode/issues/456