### PR TITLE
Use line-beginning-position instead of obsolete point-at-bol

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -734,7 +734,7 @@ buffer."
         (while (and (or (rust-in-str-or-cmnt)
                         ;; Only whitespace (or nothing) from the beginning to
                         ;; the end of the line.
-                        (looking-back "^\s*" (point-at-bol)))
+                        (looking-back "^\s*" (line-beginning-position)))
                     (= (rust-paren-level) level))
           (forward-line -1)
           (end-of-line)))


### PR DESCRIPTION
Obsolete since Emacs 29 / b7e867b841f47dcff3aeaef9b5608a237386ce70.