### PR TITLE
tests: Setup node is no longer required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
                 emacs-version:
                     - 26.3
                     - 27.2
-                    - 28.1
+                    - 28.2
                     # - snapshot
 
         steps:
@@ -21,10 +21,6 @@ jobs:
             - uses: jcs090218/setup-emacs@master
               with:
                   version: ${{ matrix.emacs-version }}
-
-            - uses: actions/setup-node@v2
-              with:
-                node-version: '16'
 
             - uses: emacs-eask/setup-eask@master
               with:

--- a/Eask
+++ b/Eask
@@ -2,6 +2,9 @@
          "1.0.4"
          "A major-mode for editing Rust source code")
 
+(website-url "https://github.com/rust-lang/rust-mode")
+(keywords "languages")
+
 (package-file "rust-mode.el")
 
 (files 


### PR DESCRIPTION
This is no longer needed for [setup-eask](https://github.com/emacs-eask/setup-eask).