### PR TITLE
Fix the issue #475

### DIFF
--- a/rust-rustfmt.el
+++ b/rust-rustfmt.el
@@ -67,7 +67,7 @@
                       (with-current-buffer buf
                         (replace-buffer-contents rust-rustfmt-buffername))
                     (copy-to-buffer buf (point-min) (point-max))))
-              (kill-buffer))
+              (kill-buffer-and-window))
              ((= ret 3)
               (if (not (string= (buffer-string)
                                 (with-current-buffer buf (buffer-string))))


### PR DESCRIPTION
Automatically remove the redundant window after calling rustfmt.  Fix the issue #475.