### PR TITLE
Abilty to customize the enabling of URL shortener for playpen

### DIFF
--- a/rust-playpen.el
+++ b/rust-playpen.el
@@ -16,6 +16,12 @@
   :type 'string
   :group 'rust-mode)
 
+(defcustom rust-playpen-enable-shortener t
+  "Enable shortended URL for playpen links."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'rust-mode)
+
 (defcustom rust-shortener-url-format "https://is.gd/create.php?format=simple&url=%s"
   "Format string to use for creating the shortened link of a playpen submission."
   :type 'string
@@ -28,26 +34,28 @@
   (interactive "r")
   (let* ((data (buffer-substring begin end))
          (escaped-data (url-hexify-string data))
-         (escaped-playpen-url (url-hexify-string
-                               (format rust-playpen-url-format escaped-data))))
+         (playpen-url (format rust-playpen-url-format escaped-data))
+         (escaped-playpen-url (url-hexify-string playpen-url)))
     (if (> (length escaped-playpen-url) 5000)
         (error "encoded playpen data exceeds 5000 character limit (length %s)"
                (length escaped-playpen-url))
-      (let ((shortener-url (format rust-shortener-url-format escaped-playpen-url))
-            (url-request-method "POST"))
-        (url-retrieve shortener-url
-                      (lambda (state)
-                        ;; filter out the headers etc. included at the
-                        ;; start of the buffer: the relevant text
-                        ;; (shortened url or error message) is exactly
-                        ;; the last line.
-                        (goto-char (point-max))
-                        (let ((last-line (thing-at-point 'line t))
-                              (err (plist-get state :error)))
-                          (kill-buffer)
-                          (if err
-                              (error "failed to shorten playpen url: %s" last-line)
-                            (message "%s" last-line)))))))))
+      (if (not rust-playpen-enable-shortener)
+          (message "%s" playpen-url)
+        (let ((shortener-url (format rust-shortener-url-format escaped-playpen-url))
+              (url-request-method "POST"))
+          (url-retrieve shortener-url
+                        (lambda (state)
+                          ;; filter out the headers etc. included at the
+                          ;; start of the buffer: the relevant text
+                          ;; (shortened url or error message) is exactly
+                          ;; the last line.
+                          (goto-char (point-max))
+                          (let ((last-line (thing-at-point 'line t))
+                                (err (plist-get state :error)))
+                            (kill-buffer)
+                            (if err
+                                (error "failed to shorten playpen url: %s" last-line)
+                              (message "%s" last-line))))))))))
 
 (defun rust-playpen-buffer ()
   "Create a shareable URL for the contents of the buffer on the Rust playpen."


### PR DESCRIPTION
This makes me share the Playpen URL directly. And this is kind of necessary for me since the region I'm out of currently, the URL shortener domain itself is blocked. Snapshot here: https://imgur.com/a/ugLLVwP