### PR TITLE
Refine the error message displaying

### DIFF
--- a/rust-rustfmt.el
+++ b/rust-rustfmt.el
@@ -149,7 +149,8 @@ rustfmt complain in the echo area."
           (goto-char (point-min))
           (forward-line (1- (car target-point)))
           (forward-char (1- (cdr target-point))))
-        (message target-problem)))))
+        (unless rust-format-show-buffer
+          (message target-problem))))))
 
 (defconst rust--format-word "\
 \\b\\(else\\|enum\\|fn\\|for\\|if\\|let\\|loop\\|\


### PR DESCRIPTION
Before this change, when `rust-format-show-buffer` is on, which is the default case, all the output from rustfmt's STDERR would be placed into the dedicated "rustfmt" buffer, and the Minibuffer, and Message buffer as well. 

Showing two identical lines of message is not necessary, and sometimes causes distraction.

Because the `rust-format-show-buffer` is a package-wide prefined customizable variable, "rustfmt" buffer should take precedence over either Minibuffer or Message buffer. And because the default behavior of Emacs's `display-buffer` (used by line [107](https://github.com/rust-lang/rust-mode/blob/master/rust-rustfmt.el#L107)) ensures that a new window will pop up. We can make a change to conditionally show error messages in Minibuffer or Message buffer, to refine the error message displaying.



