### PR TITLE
Make `rust-mode-hook` a customization variable

### DIFF
--- a/rust-cargo.el
+++ b/rust-cargo.el
@@ -63,8 +63,6 @@
   (when rust-always-locate-project-on-open
     (rust-update-buffer-project)))
 
-(add-hook 'rust-mode-hook #'rust-maybe-initialize-buffer-project)
-
 ;;; Internal
 
 (defun rust--compile (format-string &rest args)

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -56,6 +56,11 @@ This variable might soon be remove again.")
   :link '(url-link "https://www.rust-lang.org/")
   :group 'languages)
 
+(defcustom rust-mode-hook '(rust-maybe-initialize-buffer-project)
+  "Hook called by `rust-mode'."
+  :type 'hook
+  :group 'rust-mode)
+
 (defcustom rust-indent-offset 4
   "Indent Rust code by this number of spaces."
   :type 'integer


### PR DESCRIPTION
Allows rust-mode-hook to be set through custom, the same as for most other major modes.