### PR TITLE
Don’t duplicate test name.

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -2797,7 +2797,7 @@ fn foo<T:Fn() -> X<Y>>() -> Z {
      )
    ))
 
-(ert-deftest rust-test-paren-matching-lt-ops-in-fn-params ()
+(ert-deftest rust-test-paren-matching-lt-ops-in-fn-params-1 ()
   (rust-test-matching-parens
    "
 fn foo(x:i32) {
@@ -2809,7 +2809,7 @@ fn foo(x:i32) {
      )
    ))
 
-(ert-deftest rust-test-paren-matching-lt-ops-in-fn-params ()
+(ert-deftest rust-test-paren-matching-lt-ops-in-fn-params-2 ()
   (rust-test-matching-parens
    "
 fn foo(x:i32) -> bool {


### PR DESCRIPTION
Emacs 29 will signal an error in this case in batch mode, and in any case the first test in the duplicate series will never run.