### PR TITLE
Improve the usability of `rust-dbg-wrap-or-unwrap`

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -3454,6 +3454,35 @@ impl Two<'a> {
    #'rust-dbg-wrap-or-unwrap
    "let x = add(dbg!(first), second);"))
 
+(ert-deftest rust-test-dbg-wrap-empty-line ()
+  (rust-test-manip-code
+   "let a = 1;
+
+let b = 1;"
+   12
+   #'rust-dbg-wrap-or-unwrap
+   "let a = 1;
+dbg!()
+let b = 1;"))
+
+(ert-deftest rust-test-dbg-wrap-empty-before-comment ()
+  (rust-test-manip-code
+   "let a = 1;
+// comment
+let b = 1;"
+   12
+   #'rust-dbg-wrap-or-unwrap
+   "let a = 1;
+dbg!()// comment
+let b = 1;")
+  (rust-test-manip-code
+   "let a = 1;// comment
+let b = 1;"
+   11
+   #'rust-dbg-wrap-or-unwrap
+   "let a = 1;dbg!()// comment
+let b = 1;"))
+
 (ert-deftest rust-test-dbg-wrap-symbol-unbalanced ()
   (rust-test-manip-code
    "let x = add((first, second);"

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -3454,7 +3454,8 @@ impl Two<'a> {
    "let x = add(first, second);"
    15
    #'rust-dbg-wrap-or-unwrap
-   "let x = add(dbg!(first), second);"))
+   "let x = add(dbg!(first), second);"
+   24))
 
 (ert-deftest rust-test-dbg-wrap-empty-line ()
   (rust-test-manip-code
@@ -3494,7 +3495,8 @@ let b = 1;"
    "let x = add((first, second);"
    14
    #'rust-dbg-wrap-or-unwrap
-   "let x = add((dbg!(first), second);"))
+   "let x = add((dbg!(first), second);"
+   25))
 
 (ert-deftest rust-test-dbg-wrap-region ()
   (rust-test-manip-code
@@ -3505,7 +3507,8 @@ let b = 1;"
      (push-mark nil t t)
      (goto-char 26)
      (rust-dbg-wrap-or-unwrap))
-   "let x = dbg!(add(first, second));"))
+   "let x = dbg!(add(first, second));"
+   33))
 
 (defun rust-test-dbg-unwrap (position)
   (rust-test-manip-code

--- a/rust-utils.el
+++ b/rust-utils.el
@@ -38,20 +38,22 @@ visit the new file."
 
 (defun rust-insert-dbg ()
   "Insert the dbg! macro."
-  (cond ((region-active-p)
-         (when (< (mark) (point))
-           (exchange-point-and-mark))
-         (let ((old-point (point)))
-           (insert-parentheses)
-           (goto-char old-point)))
-        (t
-         (when (rust-in-str)
-           (up-list -1 t t))
-         (insert "(")
-         (forward-sexp)
-         (insert ")")
-         (backward-sexp)))
+  (when (rust-in-str)
+    (up-list -1 t t))
+  (insert "(")
+  (forward-sexp)
+  (insert ")")
+  (backward-sexp)
   (insert "dbg!"))
+
+(defun rust-insert-dbg-region ()
+  "Insert the dbg! macro around a region."
+  (when (< (mark) (point))
+    (exchange-point-and-mark))
+  (let ((old-point (point)))
+    (insert-parentheses)
+    (goto-char old-point))
+(insert "dbg!"))
 
 ;;;###autoload
 (defun rust-dbg-wrap-or-unwrap ()
@@ -59,7 +61,7 @@ visit the new file."
   (interactive)
   (save-excursion
     (if (region-active-p)
-        (rust-insert-dbg)
+        (rust-insert-dbg-region)
 
       (let ((beginning-of-symbol (ignore-errors (beginning-of-thing 'symbol))))
         (when beginning-of-symbol

--- a/rust-utils.el
+++ b/rust-utils.el
@@ -37,29 +37,30 @@ visit the new file."
 ;;; dbg! macro
 
 (defun rust-insert-dbg ()
-  "Insert the dbg! macro."
+  "Insert the dbg! macro. Move cursor to the end of macro."
   (when (rust-in-str)
     (up-list -1 t t))
   (insert "(")
   (forward-sexp)
   (insert ")")
   (backward-sexp)
-  (insert "dbg!"))
+  (insert "dbg!")
+  (forward-sexp))
 
 (defun rust-insert-dbg-region ()
-  "Insert the dbg! macro around a region."
+  "Insert the dbg! macro around a region. Move cursor to the end of macro."
   (when (< (mark) (point))
     (exchange-point-and-mark))
   (let ((old-point (point)))
     (insert-parentheses)
     (goto-char old-point))
-(insert "dbg!"))
+  (insert "dbg!")
+  (forward-sexp))
 
 (defun rust-insert-dbg-alone ()
-  "Insert the dbg! macro alone."
+  "Insert the dbg! macro alone. Move cursor in between the brackets."
   (insert "dbg!()")
   (backward-char))
-
 
 ;;;###autoload
 (defun rust-dbg-wrap-or-unwrap ()
@@ -67,13 +68,14 @@ visit the new file."
   (interactive)
   
   (cond
-   ;; alone
-   ((or (looking-at-p " *$") (looking-at-p " *//.*"))
-    (rust-insert-dbg-alone))
    
    ;; region
    ((region-active-p)
     (rust-insert-dbg-region))
+
+   ;; alone
+   ((or (looking-at-p " *$") (looking-at-p " *//.*"))
+    (rust-insert-dbg-alone))
 
    ;; symbol
    (t

--- a/rust-utils.el
+++ b/rust-utils.el
@@ -59,7 +59,7 @@ visit the new file."
 (defun rust-dbg-wrap-or-unwrap ()
   "Either remove or add the dbg! macro."
   (interactive)
-  (save-excursion
+  ;; (save-excursion
     (if (region-active-p)
         (rust-insert-dbg-region)
 
@@ -77,7 +77,9 @@ visit the new file."
                (goto-char dbg-point)
                (delete-char -4)
                (delete-pair))
-              (t (rust-insert-dbg)))))))
+              (t (rust-insert-dbg)))))
+    ;; )
+)
 
 (defun rust-toggle-mutability ()
   "Toggles the mutability of the variable defined on the current line"

--- a/rust-utils.el
+++ b/rust-utils.el
@@ -55,12 +55,22 @@ visit the new file."
     (goto-char old-point))
 (insert "dbg!"))
 
+(defun rust-insert-dbg-alone ()
+  "Insert the dbg! macro alone."
+  (insert "dbg!()")
+  (backward-char))
+
+
 ;;;###autoload
 (defun rust-dbg-wrap-or-unwrap ()
   "Either remove or add the dbg! macro."
   (interactive)
   
   (cond
+   ;; alone
+   ((or (looking-at-p " *$") (looking-at-p " *//.*"))
+    (rust-insert-dbg-alone))
+   
    ;; region
    ((region-active-p)
     (rust-insert-dbg-region))

--- a/rust-utils.el
+++ b/rust-utils.el
@@ -59,26 +59,30 @@ visit the new file."
 (defun rust-dbg-wrap-or-unwrap ()
   "Either remove or add the dbg! macro."
   (interactive)
-  ;; (save-excursion
-    (if (region-active-p)
-        (rust-insert-dbg-region)
+  
+  (cond
+   ;; region
+   ((region-active-p)
+    (rust-insert-dbg-region))
 
-      (let ((beginning-of-symbol (ignore-errors (beginning-of-thing 'symbol))))
-        (when beginning-of-symbol
-          (goto-char beginning-of-symbol)))
+   ;; symbol
+   (t
+    (let ((beginning-of-symbol (ignore-errors (beginning-of-thing 'symbol))))
+      (when beginning-of-symbol
+        (goto-char beginning-of-symbol)))
 
-      (let ((dbg-point (save-excursion
-                         (or (and (looking-at-p "dbg!") (+ 4 (point)))
-                             (ignore-errors
-                               (while (not (rust-looking-back-str "dbg!"))
-                                 (backward-up-list))
-                               (point))))))
-        (cond (dbg-point
-               (goto-char dbg-point)
-               (delete-char -4)
-               (delete-pair))
-              (t (rust-insert-dbg)))))
-    ;; )
+    (let ((dbg-point (save-excursion
+                       (or (and (looking-at-p "dbg!") (+ 4 (point)))
+                           (ignore-errors
+                             (while (not (rust-looking-back-str "dbg!"))
+                               (backward-up-list))
+                             (point))))))
+      (cond (dbg-point
+             (goto-char dbg-point)
+             (delete-char -4)
+             (delete-pair))
+            (t (rust-insert-dbg)))))
+   )
 )
 
 (defun rust-toggle-mutability ()


### PR DESCRIPTION
While the original implementation of `rust-dbg-wrap-or-unwrap` works in many cases, it has following problems:

###  Issue1. Insertion happens indiscriminately.
For example:

before:
```
*<---cursor is here
let a = 1;
```
after:
```
dbg!(
let) a = 1;
```

###  Issue2. Not handling the cursor position after `dbg!()` insertion.

Insertion of `dbg!()` indicates that user's intention to debug an expression.  if the return value is significant(case 1), the original expression must be surrounded by another expression, which means not handling the cursor position is totally fine, but if `dbg!`'s return value is insignificant(case 2), the subsequent action the user will take must be adding an trailing semicolon, for the original implementation in such cases, users must reach the end of line first(C-e or similar) and then add a semicolon. 

In fact, in practice, the second case is far more common than the first one, we can do some rough statistics on the source files of `rust-lang/rust`:
```sh
rg 'dbg!\(.*\).*[^;]$' | wc -l  # 61 the first case
rg 'dbg!\(.*\).*;$' |  wc -l  # 270 the second case
```

The point is that, whether users insert trailing semicolon or not, moving cursor to the end of `dbg!()` automatically after insertion not only does no harms, but it likely saves one keystroke for most cases.

Overall, these patches do nothing more than fixing the issues mentioned above and cutting some unnecessary branches. For the first issue , the result after fixed will be 
```
dbg!()
let a = 1;
```

### Other known issues:

1. Similar to the original implementaion, the current `rust-dbg-wrap-or-unwrap` still relies on `forward/backward-sexp` to move forward/backward the cursor. In some cases where the cursor is inside pattern match arms or a complex structure or similar, `C-c C-d` may break the code.


