### PR TITLE
Eliminate "Containing expression ends prematurely" error

### DIFF
--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -3449,13 +3449,31 @@ impl Two<'a> {
      "Foo" font-lock-type-face
      "in" font-lock-keyword-face)))
 
-(ert-deftest rust-test-dbg-wrap-symbol ()
+(ert-deftest rust-test-dbg-wrap-sexp ()
+  "a valid sexp ahead of current pos"
   (rust-test-manip-code
    "let x = add(first, second);"
    15
    #'rust-dbg-wrap-or-unwrap
    "let x = add(dbg!(first), second);"
    24))
+
+(ert-deftest rust-test-dbg-wrap-sexp-fallback ()
+  "a invalid sexp ahead of current pos"
+  ;; inside
+  (rust-test-manip-code
+   "if let Ok(val) = may_val {}"
+   27
+   #'rust-dbg-wrap-or-unwrap
+   "if let Ok(val) = may_val {dbg!()}"
+   32)
+  ;; before
+  (rust-test-manip-code
+   "let a = {}"
+   9
+   #'rust-dbg-wrap-or-unwrap
+   "let a = dbg!({})"
+   17))
 
 (ert-deftest rust-test-dbg-wrap-empty-line ()
   (rust-test-manip-code

--- a/rust-utils.el
+++ b/rust-utils.el
@@ -36,16 +36,27 @@ visit the new file."
 
 ;;; dbg! macro
 
-(defun rust-insert-dbg ()
-  "Insert the dbg! macro. Move cursor to the end of macro."
+(defun rust-insert-dbg-sexp ()
+  "Insert the dbg! macro around a sexp if possible, insert at current position
+if not. Move cursor to the end of macro."
   (when (rust-in-str)
     (up-list -1 t t))
-  (insert "(")
-  (forward-sexp)
-  (insert ")")
-  (backward-sexp)
-  (insert "dbg!")
-  (forward-sexp))
+  (setq safe-to-forward t)
+  (save-excursion
+    (condition-case nil
+        (forward-sexp)
+      (error (setq safe-to-forward nil)
+             nil)))
+  (cond
+   ((not safe-to-forward)
+    (rust-insert-dbg-alone))
+   (t
+    (insert "(")
+    (forward-sexp)
+    (insert ")")
+    (backward-sexp)
+    (insert "dbg!")
+    (forward-sexp))))
 
 (defun rust-insert-dbg-region ()
   "Insert the dbg! macro around a region. Move cursor to the end of macro."
@@ -93,7 +104,7 @@ visit the new file."
              (goto-char dbg-point)
              (delete-char -4)
              (delete-pair))
-            (t (rust-insert-dbg)))))
+            (t (rust-insert-dbg-sexp)))))
    )
 )
 


### PR DESCRIPTION
While #498 handles dbg! insertion for "empty line" cases, the original `rust-insert-dbg` remains unchanged. Though it can handle most cases where there is a valid s-expression ahead of current position, it cannot handle if there isn't, such as:
```
if let Ok(val) = a {}
____________________^ cursor is here 
```
, where it results in "Containing expression ends prematurely" error, and an incorrect insertion:
```
if let Ok(val) = a {(}
```

This patch attempts to fix this issue. And the result would  be:
```
if let Ok(val) = a {dbg!()}
```

