### PR TITLE
Match panics in `compilation-mode`

### DIFF
--- a/rust-compile.el
+++ b/rust-compile.el
@@ -34,6 +34,12 @@ See `compilation-error-regexp-alist' for help on their format.")
   "Specifications for matching code references in rustc invocations.
 See `compilation-error-regexp-alist' for help on their format.")
 
+(defvar rustc-panics-compilation-regexps
+   (let ((re (concat "thread '[^']+' panicked at " rustc-compilation-location)))
+     (cons re '(2 3 4 nil 1)))
+   "Specifications for matching panics in rustc invocations.
+See `compilation-error-regexp-alist' for help on their format.")
+
 ;; Match test run failures and panics during compilation as
 ;; compilation warnings
 (defvar cargo-compilation-regexps
@@ -75,6 +81,9 @@ the compilation window until the top of the error is visible."
      (add-to-list 'compilation-error-regexp-alist 'rustc-colon)
      (add-to-list 'compilation-error-regexp-alist-alist
                   (cons 'cargo cargo-compilation-regexps))
+     (add-to-list 'compilation-error-regexp-alist-alist
+                  (cons 'rustc-panics rustc-panics-compilation-regexps))
+     (add-to-list 'compilation-error-regexp-alist 'rustc-panics)
      (add-to-list 'compilation-error-regexp-alist 'cargo)
      (add-hook 'next-error-hook #'rustc-scroll-down-after-next-error)))
 

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -3600,6 +3600,7 @@ let b = 1;"
     (insert "warning found a -> b\n  --> file3.rs:12:34\n\n")
     (insert "note: `ZZZ` could also refer to the constant imported here -> b\n  --> file4.rs:12:34\n\n")
     (insert "    ::: file5.rs:12:34\n\n")
+    (insert "thread 'main' panicked at src/file7.rs:12:34:\n\n")
     ;; should not match
     (insert "werror found a -> b\n  --> no_match.rs:12:34\n\n")
     (insert "error[E0061]: this function takes 1 parameter but 2 parameters were supplied\n  --> file6.rs:132:34
@@ -3618,11 +3619,13 @@ let b = 1;"
                 ("file6.rs" "132" "34" compilation-error "file6.rs:132:34"))
                (("file5.rs" "12" "34" compilation-info "file5.rs:12:34"))
                ((like-previous-one "82" back-to-indentation compilation-info "82")
-                (like-previous-one "132" back-to-indentation compilation-info "132")))
+                (like-previous-one "132" back-to-indentation compilation-info "132"))
+               (("src/file7.rs" "12" "34" nil "src/file7.rs:12:34")))
              (mapcar #'rust-collect-matches
                      (list rustc-compilation-regexps
                            rustc-colon-compilation-regexps
-                           rustc-refs-compilation-regexps))))))
+                           rustc-refs-compilation-regexps
+                           rustc-panics-compilation-regexps))))))
 
 ;; If electric-pair-mode is available, load it and run the tests that use it.  If not,
 ;; no error--the tests will be skipped.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-mode/issues/507.

If we encounter a panic when executing Rust code in `compilation-mode`, we now correctly highlight the location where the panic occurred.

For example:

```
thread 'main' panicked at src/main.rs:2:5:
explicit panic
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Here, `src/main.rs:2:5` is highlighted. The developer is then able to execute `compile-goto-error` to jump to the correct spot in the code.