### PR TITLE
Remove autoload for prog-mode based rust-mode

### DIFF
--- a/rust-prog-mode.el
+++ b/rust-prog-mode.el
@@ -1445,7 +1445,6 @@ whichever comes first."
            (goto-char (match-end 0)))))))
    (point) end))
 
-;;;###autoload
 (define-derived-mode rust-mode prog-mode "Rust"
   "Major mode for Rust code.
 


### PR DESCRIPTION
The load of specific rust-mode now depends on the tree sitter variable that we have, so disabling autoload for this too.