### PR TITLE
Fix rust-mode lazy loading

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -76,6 +76,9 @@ instead of `prog-mode'. This option requires emacs29+."
   (require 'rust-prog-mode))
 
 ;;;###autoload
+(autoload 'rust-mode "rust-mode" "Major mode for Rust code.")
+
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))
 
 (provide 'rust-mode)


### PR DESCRIPTION
This PR fixes the following error that happends when opening a .rs
file:

	File mode specification error: (void-function rust-mode)

It conditionally autoloads the proper rust-mode version depending on
the user environment.

Fixes #528