### PR TITLE
Allow autoloaded rust-mode function to be called interactively

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -76,7 +76,7 @@ instead of `prog-mode'. This option requires emacs29+."
   (require 'rust-prog-mode))
 
 ;;;###autoload
-(autoload 'rust-mode "rust-mode" "Major mode for Rust code.")
+(autoload 'rust-mode "rust-mode" "Major mode for Rust code." t)
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))


### PR DESCRIPTION
This PR updates the autoload call so the rust-mode function can be
called interactively (using `M-x`).