### PR TITLE
Fix ancient defect and dependency complications related to having two rust-mode implementations

### DIFF
--- a/rust-mode-treesitter.el
+++ b/rust-mode-treesitter.el
@@ -5,12 +5,13 @@
 
 ;;; Code:
 
+(require 'rust-mode)
+
+;; Do not compile or load on Emacs releases that don't support
+;; this.  See https://github.com/rust-lang/rust-mode/issues/520.
 (when (version<= "29.1" emacs-version)
-  ;; We have the when macro because of
-  ;; https://github.com/rust-lang/rust-mode/issues/520
   (require 'treesit)
   (require 'rust-ts-mode)
-  (require 'rust-common)
 
   (define-derived-mode rust-mode rust-ts-mode "Rust"
     "Major mode for Rust code.

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -71,10 +71,6 @@ instead of `prog-mode'. This option requires emacs29+."
     map)
   "Keymap for Rust major mode.")
 
-(if (and (version<= "29.1" emacs-version) rust-mode-treesitter-derive)
-    (require 'rust-mode-treesitter)
-  (require 'rust-prog-mode))
-
 ;;;###autoload
 (autoload 'rust-mode "rust-mode" "Major mode for Rust code." t)
 
@@ -82,6 +78,12 @@ instead of `prog-mode'. This option requires emacs29+."
 (add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))
 
 (provide 'rust-mode)
+
+(if (and rust-mode-treesitter-derive
+         (version<= "29.1" emacs-version))
+    (require 'rust-mode-treesitter)
+  (require 'rust-prog-mode))
+
 (require 'rust-utils)
 
 ;;; rust-mode.el ends here

--- a/rust-prog-mode.el
+++ b/rust-prog-mode.el
@@ -4,7 +4,8 @@
 ;; rust-mode code deriving from prog-mode instead of rust-ts-mode
 
 ;;; Code:
-(require 'rust-common)
+
+(require 'rust-mode)
 
 (defvar electric-pair-inhibit-predicate)
 (defvar electric-pair-skip-self)

--- a/rust-rustfmt.el
+++ b/rust-rustfmt.el
@@ -87,8 +87,8 @@
                 (insert-file-contents tmpf)
                 (rust--format-fix-rustfmt-buffer (buffer-name buf))
                 (error "Rustfmt failed, see %s buffer for details"
-                       rust-rustfmt-buffername))))
-          (delete-file tmpf))))))
+                       rust-rustfmt-buffername)))
+            (delete-file tmpf)))))))
 
 ;; Since we run rustfmt through stdin we get <stdin> markers in the
 ;; output. This replaces them with the buffer name instead.


### PR DESCRIPTION
```
lib/rust-mode/rust-mode-treesitter.el:21:33: Warning: reference to free variable ‘rust-before-save-hook’
lib/rust-mode/rust-mode-treesitter.el:22:32: Warning: reference to free variable ‘rust-after-save-hook’
```

and

```
lib/rust-mode/rust-rustfmt.el:60:12: Warning: ‘unwind-protect’ without unwind forms
```