### PR TITLE
fix: move indent level to rust-common

### DIFF
--- a/rust-common.el
+++ b/rust-common.el
@@ -16,5 +16,11 @@
   :type 'function
   :group 'rust-mode)
 
+(defcustom rust-indent-offset 4
+  "Indent Rust code by this number of spaces."
+  :type 'integer
+  :group 'rust-mode
+  :safe #'integerp)
+
 (provide 'rust-common)
 ;;; rust-common.el ends here

--- a/rust-prog-mode.el
+++ b/rust-prog-mode.el
@@ -17,12 +17,6 @@
     ("INFINITY" . ?∞) ("->" . ?→) ("=>" . ?⇒))
   "Alist of symbol prettifications used for `prettify-symbols-alist'.")
 
-(defcustom rust-indent-offset 4
-  "Indent Rust code by this number of spaces."
-  :type 'integer
-  :group 'rust-mode
-  :safe #'integerp)
-
 (defcustom rust-indent-method-chain nil
   "Indent Rust method chains, aligned by the `.' operators."
   :type 'boolean


### PR DESCRIPTION
Emacs complains that `rust-indent-offset`
isn't set and a few minor modes (e.g.
formatting, smartparens) stop working.
This moves that variable to the common
file so the treesitter mode has the
variable set.

I'm not sure why more of the rust-prog-mode variables aren't in the rust-common file so I left them there. But, this was the only variable that was causing breakage for me. There is a rust-ts-mode-indent-offset variable too (which is also 4 by default) - should rust-mode override that variable with this one, override the rust-mode variable with the tree sitter one when the tree sitter mode is on, or keep them independent?