### PR TITLE
fix(treesit): auto mode precedence of rust-mode

### DIFF
--- a/rust-mode-treesitter.el
+++ b/rust-mode-treesitter.el
@@ -13,6 +13,12 @@
   (require 'treesit)
   (require 'rust-ts-mode)
 
+  ;; HACK: `rust-ts-mode' adds itself to the `auto-mode-alist'
+  ;; after us, so we need to readd `rust-mode' to the front of
+  ;; the list after loading `rust-ts-mode'.
+  (setq auto-mode-alist (delete '("\\.rs\\'" . rust-mode) auto-mode-alist))
+  (add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))
+
   (define-derived-mode rust-mode rust-ts-mode "Rust"
     "Major mode for Rust code.
 


### PR DESCRIPTION
Currently, `rust-ts-mode` will add itself to
the `auto-mode-alist` when it is loaded, which
is after the autoload for adding `rust-mode`.
We need to re-add `rust-mode` after loading the
treesitter package to make sure this mode has
higher priority.