### PR TITLE
Update rustfmt's default edition: 2018 -> 2021

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Update rustfmt's defaults to use 2021 edition ([#554](https://github.com/rust-lang/rust-mode/issues/509)).
+
 # v1.0.6
 
 - Add support for treesitter mode.

--- a/rust-rustfmt.el
+++ b/rust-rustfmt.el
@@ -30,7 +30,7 @@
   :type 'string
   :group 'rust-mode)
 
-(defcustom rust-rustfmt-switches '("--edition" "2018")
+(defcustom rust-rustfmt-switches '("--edition" "2021")
   "Arguments to pass when invoking the `rustfmt' executable."
   :type '(repeat string)
   :group 'rust-mode)


### PR DESCRIPTION
The latest edition seems like a good default.