### PR TITLE
Ensure rustfmt is invoked without edition parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
       - uses: jcs090218/setup-emacs@master
         with:
           version: ${{ matrix.emacs-version }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
       - uses: emacs-eask/setup-eask@master
         with:
           version: "snapshot"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Unreleased
 
-- Update rustfmt's defaults to use 2024 edition ([#566](https://github.com/rust-lang/rust-mode/issues/509)).
-- Update rustfmt's defaults to use 2021 edition ([#554](https://github.com/rust-lang/rust-mode/issues/509)).
+- Ensure rustfmt is invoked without overriding parameters [#571](https://github.com/rust-lang/rust-mode/pull/571)
+- Fix native compilation warnings ([#509](https://github.com/rust-lang/rust-mode/issues/509)).
 - Introduce `rust-format-mode` for `rust-format-buffer` ([#556](https://github.com/rust-lang/rust-mode/pull/556)).
 
 # v1.0.6

--- a/rust-cargo-tests.el
+++ b/rust-cargo-tests.el
@@ -21,6 +21,13 @@
        (find-file main-file)
        ,expr)))
 
+(defmacro rust-test--with-snippet-buffer (expr)
+  `(let* ((test-dir (expand-file-name "test-project/" default-directory))
+          (snippet-file (expand-file-name "src/rustfmt-default.rs" test-dir)))
+     (save-current-buffer
+       (find-file snippet-file)
+       ,expr)))
+
 (defun rust-test--find-string (string)
   "Find STRING in current buffer."
   (goto-char (point-min))
@@ -70,3 +77,13 @@
       (should (eq major-mode 'rust-format-mode))
       (should (rust-test--find-string "error:")))
     (kill-buffer "*rustfmt*")))
+
+(ert-deftest rust-test-respect-rustfmt-defaults ()
+  (skip-unless (executable-find "rustfmt"))
+  (rust-test--with-snippet-buffer
+   (let ((old-content (buffer-string))
+             (ret (rust-format-buffer)))
+         (should (string= old-content (buffer-string))))))
+
+(ert-deftest rust-test-ensure-rustfmt-switches-nil ()
+  (should (eq rust-rustfmt-switches nil)))

--- a/rust-rustfmt.el
+++ b/rust-rustfmt.el
@@ -33,8 +33,10 @@
   :type 'string
   :group 'rust-mode)
 
-(defcustom rust-rustfmt-switches '("--edition" "2024")
-  "Arguments to pass when invoking the `rustfmt' executable."
+(defcustom rust-rustfmt-switches nil
+  "Arguments to pass when invoking the `rustfmt' executable. This variable
+will override any user configuration (e.g. rustfmt.toml). Recommendation
+is to not modify this and rely on declarative configuration instead."
   :type '(repeat string)
   :group 'rust-mode)
 

--- a/test-project/src/rustfmt-default.rs
+++ b/test-project/src/rustfmt-default.rs
@@ -1,0 +1,5 @@
+// this file ensures that by default rustfmt is invoked without parameters
+// and formats with its default (--edition=2015 as of today)
+
+// With --edition=2024 this import will be reordered
+use std::{i16, i8};


### PR DESCRIPTION
Fixes #570 

`rustfmt` should probably be invoked without defaulting to any `--edition` parameter as it collides with a user configuration in a `rustfmt.toml` or with the rustfmt default ([2015 edition](https://rust-lang.github.io/rustfmt/?version=v1.8.0#edition) at the time of this patch).

This patch sets `rust-rustfmt-switches` to nil so in a sense, I think this could be a breaking change?

I've added a test to ensure that it stays so. The test is a bit flaky, it doesn't use a rutfmt.toml so it's not completely isolated. But I'm an Emacs newbie, so :shrug: 

Happy to receive feedback. Thanks for the review!

r? @psibi 