### PR TITLE
Don't hang when the beginning of the error can't be found

### DIFF
--- a/rust-compile.el
+++ b/rust-compile.el
@@ -75,8 +75,8 @@ the compilation window until the top of the error is visible."
         (let ((start-of-error
                (save-excursion
                  (beginning-of-line)
-                 (while (not (looking-at "^[a-z]+:\\|^[a-z]+\\[E[0-9]+\\]:"))
-                   (forward-line -1))
+                 (while (and (not (looking-at "^[a-z]+:\\|^[a-z]+\\[E[0-9]+\\]:"))
+                             (equal (forward-line -1) 0)))
                  (point))))
           (set-window-start (selected-window) start-of-error))))))
 


### PR DESCRIPTION
Tools that interfere with rustc output can cause the line to be prefixed (see https://github.com/DioxusLabs/dioxus/issues/4547), which can cause the line never to be found, and the loop to continue until the user presses C-g