### PR TITLE
imenu: also support const and static items

### DIFF
--- a/rust-prog-mode.el
+++ b/rust-prog-mode.el
@@ -141,7 +141,7 @@ to the function arguments.  When nil, `->' will be indented one level."
 (defvar rust-imenu-generic-expression
   (append (mapcar #'(lambda (x)
                       (list (capitalize x) (rust-re-item-def-imenu x) 1))
-                  '("enum" "struct" "union" "type" "mod" "fn" "trait" "impl"))
+                  '("enum" "struct" "union" "type" "mod" "fn" "trait" "impl" "const" "static"))
           `(("Macro" ,(rust-re-item-def-imenu "macro_rules!") 1)))
   "Value for `imenu-generic-expression' in Rust mode.
 


### PR DESCRIPTION
This makes imenu also list const and static declarations, e.g. https://doc.rust-lang.org/rust-by-example/custom_types/constants.html