### PR TITLE
Handle thread IDs in panic output

### DIFF
--- a/rust-compile.el
+++ b/rust-compile.el
@@ -41,9 +41,10 @@ See `compilation-error-regexp-alist' for help on their format.")
 See `compilation-error-regexp-alist' for help on their format.")
 
 (defvar rustc-panics-compilation-regexps
-   (let ((re (concat "thread '[^']+' panicked at " rustc-compilation-location)))
-     (cons re '(2 3 4 nil 1)))
-   "Specifications for matching panics in rustc invocations.
+  (let ((re (concat "thread '[^']+'\\(?: ([0-9]+)\\)? panicked at "
+                    rustc-compilation-location)))
+    (cons re '(2 3 4 nil 1)))
+  "Specifications for matching panics in rustc invocations.
 See `compilation-error-regexp-alist' for help on their format.")
 
 ;; Match test run failures and panics during compilation as

--- a/rust-mode-tests.el
+++ b/rust-mode-tests.el
@@ -3715,6 +3715,7 @@ let b = 1;"
     (insert "note: `ZZZ` could also refer to the constant imported here -> b\n  --> file4.rs:12:34\n\n")
     (insert "    ::: file5.rs:12:34\n\n")
     (insert "thread 'main' panicked at src/file7.rs:12:34:\n\n")
+    (insert "thread 'aaa::bbb' (19178688) panicked at crates/a/src/b.rs:13:9:\n\n")
     (insert "[src/file8.rs:159:5] symbol_value(SOME_VAR) = Some(\n\n")
     (insert "    at file9.rs:12:34\n\n")
     ;; should not match
@@ -3736,7 +3737,8 @@ let b = 1;"
                (("file5.rs" "12" "34" compilation-info "file5.rs:12:34"))
                ((like-previous-one "82" back-to-indentation compilation-info "82")
                 (like-previous-one "132" back-to-indentation compilation-info "132"))
-               (("src/file7.rs" "12" "34" nil "src/file7.rs:12:34"))
+               (("src/file7.rs" "12" "34" nil "src/file7.rs:12:34")
+                ("crates/a/src/b.rs" "13" "9" nil "crates/a/src/b.rs:13:9"))
                (("src/file8.rs" "159" "5" compilation-info "src/file8.rs:159:5"))
                (("file9.rs" "12" "34" compilation-info "file9.rs:12:34")))
              (mapcar #'rust-collect-matches


### PR DESCRIPTION
Rust 1.91 includes the OS thread ID in panic messages, for example:

```text
thread 'aaa::bbb' (19178688) panicked at crates/a/src/b.rs:13:9:
```

The existing panic regexp only handled the older form without the thread ID:

```text
thread 'aaa::bbb' panicked at crates/a/src/b.rs:13:9:
```

This updates `rustc-panics-compilation-regexps` to accept the optional thread ID.

**Note:** This is a backward-compatible regexp change. It keeps matching the pre-1.91 panic format and adds support for the new format with an optional thread ID.

**Ref:** https://github.com/rust-lang/rust/pull/115746.