### PR TITLE
Fix byte-compile warnings and correct minimum Emacs version

### DIFF
--- a/.github/workflows/byte-compile.yml
+++ b/.github/workflows/byte-compile.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         emacs-version:
-          - "25.1"
+          - "26.1"
           - "30.1"
           - snapshot
     steps:

--- a/.github/workflows/byte-compile.yml
+++ b/.github/workflows/byte-compile.yml
@@ -1,0 +1,44 @@
+name: Byte-compile
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  byte-compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version:
+          - "25.1"
+          - "30.1"
+          - snapshot
+    steps:
+      - uses: actions/checkout@v5
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+      - name: Byte-compile with warnings as errors
+        run: |
+          emacs -Q --batch -L . \
+            --eval '(setq byte-compile-error-on-warn t)' \
+            --eval '(let ((files (list "rust-cargo.el" "rust-common.el"
+                                       "rust-compile.el" "rust-mode.el"
+                                       "rust-playpen.el" "rust-prog-mode.el"
+                                       "rust-rustfmt.el" "rust-utils.el"))
+                          (ok t))
+                      (when (version<= "29.1" emacs-version)
+                        (setq files
+                              (append files (list "rust-mode-treesitter.el"))))
+                      (dolist (f files)
+                        (unless (byte-compile-file f)
+                          (setq ok nil)))
+                      (unless ok (kill-emacs 1)))'

--- a/rust-cargo.el
+++ b/rust-cargo.el
@@ -6,6 +6,7 @@
 ;;; Code:
 
 (require 'json)
+(require 'subr-x)
 
 ;;; Options
 

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -4,7 +4,7 @@
 ;; Author: Mozilla <rust-mode@noreply.github.com>
 ;; Url: https://github.com/rust-lang/rust-mode
 ;; Keywords: languages
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "26.1"))
 
 ;; This file is distributed under the terms of both the MIT license and the
 ;; Apache License (version 2.0).

--- a/rust-prog-mode.el
+++ b/rust-prog-mode.el
@@ -922,11 +922,12 @@ and end."
 (defun rust-string-interpolation-matcher (limit)
   "Match next Rust interpolation marker before LIMIT and set match data if found.
 Returns nil if not within a Rust string."
-  (when-let (((rust-in-str))
-             (match (rust-next-string-interpolation limit)))
-    (set-match-data match)
-    (goto-char (cadr match))
-    match))
+  (when (rust-in-str)
+    (let ((match (rust-next-string-interpolation limit)))
+      (when match
+        (set-match-data match)
+        (goto-char (cadr match))
+        match))))
 
 (defun rust-syntax-class-before-point ()
   (when (> (point) 1)
@@ -950,18 +951,19 @@ Returns nil if not within a Rust string."
    ;; we're looking back at this, we want to end up just after "Fn".
    ((member (char-before) '(?\] ?\) ))
     (let ((is-paren (rust-looking-back-str ")")))
-      (when-let ((dest (save-excursion
+      (let ((dest (save-excursion
+                    (backward-sexp)
+                    (rust-rewind-irrelevant)
+                    (or
+                     (when (rust-looking-back-str "->")
+                       (backward-char 2)
+                       (rust-rewind-irrelevant)
+                       (when (rust-looking-back-str ")")
                          (backward-sexp)
-                         (rust-rewind-irrelevant)
-                         (or
-                          (when (rust-looking-back-str "->")
-                            (backward-char 2)
-                            (rust-rewind-irrelevant)
-                            (when (rust-looking-back-str ")")
-                              (backward-sexp)
-                              (point)))
-                          (and is-paren (point))))))
-        (goto-char dest))))))
+                         (point)))
+                     (and is-paren (point))))))
+        (when dest
+          (goto-char dest)))))))
 
 (defun rust-rewind-to-decl-name ()
   "Return the point at the beginning of the name in a declaration.
@@ -1548,8 +1550,9 @@ whichever comes first."
 (defun rust-syntax-propertize (start end)
   "A `syntax-propertize-function' to apply properties from START to END."
   (goto-char start)
-  (when-let ((str-start (rust-in-str-or-cmnt)))
-    (rust--syntax-propertize-raw-string str-start end))
+  (let ((str-start (rust-in-str-or-cmnt)))
+    (when str-start
+      (rust--syntax-propertize-raw-string str-start end)))
   (funcall
    (syntax-propertize-rules
     ;; Character literals.


### PR DESCRIPTION
This PR resolves the byte-compile warnings emitted by rust-mode and
corrects the declared minimum Emacs version to match the features the
package actually uses. All changes are behaviour-preserving.

## Fixes

### Obsolete `when-let` macro (rust-prog-mode.el)

`when-let` is obsolete as of Emacs 31.1 and emits a byte-compile
warning. Because the package supports older Emacs versions, `when-let*`
(introduced in Emacs 26.1) is not a drop-in replacement at the lowest
supported version. The three usages are rewritten using `let` plus
`when`, available on all supported versions, preserving the original
short-circuiting evaluation order.

### Incorrect minimum Emacs version

rust-cargo.el calls `file-local-name`, introduced in Emacs 26.1, so the
package never ran on the declared minimum of Emacs 25.1. The
Package-Requires header is updated to `((emacs "26.1"))`, matching the
oldest version already exercised by the test matrix.

rust-cargo.el also uses `string-trim` from subr-x, which was only
required at compile time via rust-mode.el. On Emacs versions before 28
(where subr-x is not preloaded) this leaves the symbol undefined at
runtime and unknown to the byte-compiler. A runtime `(require 'subr-x)`
is added to rust-cargo.el.

## CI

A new `byte-compile.yml` workflow byte-compiles the package with
`byte-compile-error-on-warn` enabled, on the minimum (26.1), the current
stable (30.1), and the development snapshot, so new warnings fail CI.
The treesitter integration file is only compiled on Emacs 29.1 and
later, matching its runtime guard. GitHub Actions stay current via the
existing dependabot configuration.

## Residual warnings

None. The package byte-compiles cleanly with warnings as errors on
Emacs 26.1, 30.1, and snapshot.